### PR TITLE
fix: replaced fspiop 1.1 spec with the one generated by api-snippets

### DIFF
--- a/fspiop-api/documents/v1.1-document-set/fspiop-v1.1-openapi3-implementation.yaml
+++ b/fspiop-api/documents/v1.1-document-set/fspiop-v1.1-openapi3-implementation.yaml
@@ -1,12 +1,35 @@
 openapi: 3.0.2
 info:
   version: "1.1"
-  title: Open API for FSP Interoperability (FSPIOP) Implementation friendly version
+  title: Open API for FSP Interoperability (FSPIOP)
   description: >-
-    Based on [API Definition updated on 2020-05-19 Version 1.1](https://github.com/mojaloop/mojaloop-specification/blob/master/documents/v1.1-document-set/API%20Definition_v1.1.pdf).
+    Revision date: 2023-11-23 Based on [API Definition updated on 2020-05-19
+    Version
+    1.1](https://github.com/mojaloop/mojaloop-specification/blob/main/documents/v1.1-document-set/API%20Definition_v1.1.pdf).
 
+    This is implementation friendly version of the API definition. It excludes
+    the following schemas from the FSPIOP api specification which are not used
+    in any of the complex types or data model of the messages.
+      - BinaryString
+      - BinaryString32
+      - Date
+      - Integer
+      - Name
+      - PersonalIdentifierType
+      - TokenCode
+      - Transaction
+      - UndefinedEnum
 
-    **Note:** The API supports a maximum size of 65536 bytes (64 Kilobytes) in the HTTP header.
+    It includes the below definitions needed for third-party functionality. -
+    AuthenticationType
+      - U2F enum
+    - AuthenticationValue
+      - oneOf is changed to anyOf
+      - new element is added U2FPinValue
+    - New element U2FPIN
+
+    **Note:** The API supports a maximum size of 65536 bytes (64 Kilobytes) in
+    the HTTP header.
   license:
     name: CC BY-ND 4.0
     url: https://github.com/mojaloop/mojaloop-specification/blob/main/LICENSE.md

--- a/fspiop-api/documents/v1.1-document-set/fspiop-v1.1-openapi3-implementation.yaml
+++ b/fspiop-api/documents/v1.1-document-set/fspiop-v1.1-openapi3-implementation.yaml
@@ -1,35 +1,31 @@
-openapi: "3.0.2"
+openapi: 3.0.2
 info:
   version: "1.1"
-  title: Open API for FSP Interoperability (FSPIOP)
-  description:
+  title: Open API for FSP Interoperability (FSPIOP) Implementation friendly version
+  description: >-
     Based on [API Definition updated on 2020-05-19 Version 1.1](https://github.com/mojaloop/mojaloop-specification/blob/master/documents/v1.1-document-set/API%20Definition_v1.1.pdf).
 
 
     **Note:** The API supports a maximum size of 65536 bytes (64 Kilobytes) in the HTTP header.
   license:
     name: CC BY-ND 4.0
-    url: https://github.com/mojaloop/mojaloop-specification/blob/master/LICENSE.md
+    url: https://github.com/mojaloop/mojaloop-specification/blob/main/LICENSE.md
   contact:
-    name: "Sam Kummary"
+    name: Sam Kummary
     url: https://github.com/mojaloop/mojaloop-specification/issues
 servers:
-  - url: "{protocol}://hostname:<port>/switch/"
+  - url: protocol://hostname:<port>/switch/
     variables:
       protocol:
         enum:
           - http
           - https
         default: https
-
 paths:
-  #Participants
   /participants/{Type}/{ID}:
     parameters:
-      #Path
       - $ref: "#/components/parameters/Type"
       - $ref: "#/components/parameters/ID"
-      #Headers
       - $ref: "#/components/parameters/Content-Type"
       - $ref: "#/components/parameters/Date"
       - $ref: "#/components/parameters/X-Forwarded-For"
@@ -40,13 +36,18 @@ paths:
       - $ref: "#/components/parameters/FSPIOP-URI"
       - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     post:
-      description: The HTTP request `POST /participants/{Type}/{ID}` (or `POST /participants/{Type}/{ID}/{SubId}`) is used to create information in the server regarding the provided identity, defined by `{Type}`, `{ID}`, and optionally `{SubId}` (for example, `POST /participants/MSISDN/123456789` or `POST /participants/BUSINESS/shoecompany/employee1`). An ExtensionList element has been added to this reqeust in version v1.1
+      description: >-
+        The HTTP request `POST /participants/{Type}/{ID}` (or `POST
+        /participants/{Type}/{ID}/{SubId}`) is used to create information in the
+        server regarding the provided identity, defined by `{Type}`, `{ID}`, and
+        optionally `{SubId}` (for example, `POST /participants/MSISDN/123456789`
+        or `POST /participants/BUSINESS/shoecompany/employee1`). An
+        ExtensionList element has been added to this reqeust in version v1.1
       summary: Create participant information
       tags:
         - participants
       operationId: ParticipantsByIDAndType
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
         - $ref: "#/components/parameters/Content-Length"
       requestBody:
@@ -57,60 +58,72 @@ paths:
             schema:
               $ref: "#/components/schemas/ParticipantsTypeIDSubIDPostRequest"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     get:
-      description: The HTTP request `GET /participants/{Type}/{ID}` (or `GET /participants/{Type}/{ID}/{SubId}`) is used to find out in which FSP the requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}`, is located (for example, `GET /participants/MSISDN/123456789`, or `GET /participants/BUSINESS/shoecompany/employee1`). This HTTP request should support a query string for filtering of currency. To use filtering of currency, the HTTP request `GET /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is the requested currency.
+      description: >-
+        The HTTP request `GET /participants/{Type}/{ID}` (or `GET
+        /participants/{Type}/{ID}/{SubId}`) is used to find out in which FSP the
+        requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}`,
+        is located (for example, `GET /participants/MSISDN/123456789`, or `GET
+        /participants/BUSINESS/shoecompany/employee1`). This HTTP request should
+        support a query string for filtering of currency. To use filtering of
+        currency, the HTTP request `GET /participants/{Type}/{ID}?currency=XYZ`
+        should be used, where `XYZ` is the requested currency.
       summary: Look up participant information
       tags:
         - participants
       operationId: ParticipantsByTypeAndID
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     put:
-      description: The callback `PUT /participants/{Type}/{ID}` (or `PUT /participants/{Type}/{ID}/{SubId}`) is used to inform the client of a successful result of the lookup, creation, or deletion of the FSP information related to the Party. If the FSP information is deleted, the fspId element should be empty; otherwise the element should include the FSP information for the Party.
+      description: >-
+        The callback `PUT /participants/{Type}/{ID}` (or `PUT
+        /participants/{Type}/{ID}/{SubId}`) is used to inform the client of a
+        successful result of the lookup, creation, or deletion of the FSP
+        information related to the Party. If the FSP information is deleted, the
+        fspId element should be empty; otherwise the element should include the
+        FSP information for the Party.
       summary: Return participant information
       tags:
         - participants
       operationId: ParticipantsByTypeAndID3
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Participant information returned.
@@ -120,68 +133,78 @@ paths:
             schema:
               $ref: "#/components/schemas/ParticipantsTypeIDPutResponse"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     delete:
-      description:
-        The HTTP request `DELETE /participants/{Type}/{ID}` (or `DELETE /participants/{Type}/{ID}/{SubId}`) is used to delete information in the server regarding the provided identity, defined by `{Type}` and `{ID}`) (for example, `DELETE /participants/MSISDN/123456789`), and optionally `{SubId}`. This HTTP request should support a query string to delete FSP information regarding a specific currency only. To delete a specific currency only, the HTTP request `DELETE /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is the requested currency.
+      description: >-
+        The HTTP request `DELETE /participants/{Type}/{ID}` (or `DELETE
+        /participants/{Type}/{ID}/{SubId}`) is used to delete information in the
+        server regarding the provided identity, defined by `{Type}` and `{ID}`)
+        (for example, `DELETE /participants/MSISDN/123456789`), and optionally
+        `{SubId}`. This HTTP request should support a query string to delete FSP
+        information regarding a specific currency only. To delete a specific
+        currency only, the HTTP request `DELETE
+        /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is
+        the requested currency.
 
 
-        **Note:** The Account Lookup System should verify that it is the Party’s current FSP that is deleting the FSP information.
+        **Note:** The Account Lookup System should verify that it is the Party’s
+        current FSP that is deleting the FSP information.
       summary: Delete participant information
       tags:
         - participants
       operationId: ParticipantsByTypeAndID2
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /participants/{Type}/{ID}/error:
     put:
-      description: If the server is unable to find, create or delete the associated FSP of the provided identity, or another processing error occurred, the error callback `PUT /participants/{Type}/{ID}/error` (or `PUT /participants/{Type}/{ID}/{SubId}/error`) is used.
+      description: >-
+        If the server is unable to find, create or delete the associated FSP of
+        the provided identity, or another processing error occurred, the error
+        callback `PUT /participants/{Type}/{ID}/error` (or `PUT
+        /participants/{Type}/{ID}/{SubId}/error`) is used.
       summary: Return participant information error
       tags:
         - participants
       operationId: ParticipantsErrorByTypeAndID
       parameters:
-        #Path
         - $ref: "#/components/parameters/Type"
         - $ref: "#/components/parameters/ID"
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
         - $ref: "#/components/parameters/Date"
@@ -200,31 +223,29 @@ paths:
             schema:
               $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /participants/{Type}/{ID}/{SubId}:
     parameters:
-      #Path
       - $ref: "#/components/parameters/Type"
       - $ref: "#/components/parameters/ID"
       - $ref: "#/components/parameters/SubId"
-      #Headers
       - $ref: "#/components/parameters/Content-Type"
       - $ref: "#/components/parameters/Date"
       - $ref: "#/components/parameters/X-Forwarded-For"
@@ -235,13 +256,18 @@ paths:
       - $ref: "#/components/parameters/FSPIOP-URI"
       - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     post:
-      description: The HTTP request `POST /participants/{Type}/{ID}` (or `POST /participants/{Type}/{ID}/{SubId}`) is used to create information in the server regarding the provided identity, defined by `{Type}`, `{ID}`, and optionally `{SubId}` (for example, `POST /participants/MSISDN/123456789` or `POST /participants/BUSINESS/shoecompany/employee1`). An ExtensionList element has been added to this reqeust in version v1.1
+      description: >-
+        The HTTP request `POST /participants/{Type}/{ID}` (or `POST
+        /participants/{Type}/{ID}/{SubId}`) is used to create information in the
+        server regarding the provided identity, defined by `{Type}`, `{ID}`, and
+        optionally `{SubId}` (for example, `POST /participants/MSISDN/123456789`
+        or `POST /participants/BUSINESS/shoecompany/employee1`). An
+        ExtensionList element has been added to this reqeust in version v1.1
       summary: Create participant information
       tags:
         - participants
       operationId: ParticipantsSubIdByTypeAndIDPost
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
         - $ref: "#/components/parameters/Content-Length"
       requestBody:
@@ -252,60 +278,72 @@ paths:
             schema:
               $ref: "#/components/schemas/ParticipantsTypeIDSubIDPostRequest"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     get:
-      description: The HTTP request `GET /participants/{Type}/{ID}` (or `GET /participants/{Type}/{ID}/{SubId}`) is used to find out in which FSP the requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}`, is located (for example, `GET /participants/MSISDN/123456789`, or `GET /participants/BUSINESS/shoecompany/employee1`). This HTTP request should support a query string for filtering of currency. To use filtering of currency, the HTTP request `GET /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is the requested currency.
+      description: >-
+        The HTTP request `GET /participants/{Type}/{ID}` (or `GET
+        /participants/{Type}/{ID}/{SubId}`) is used to find out in which FSP the
+        requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}`,
+        is located (for example, `GET /participants/MSISDN/123456789`, or `GET
+        /participants/BUSINESS/shoecompany/employee1`). This HTTP request should
+        support a query string for filtering of currency. To use filtering of
+        currency, the HTTP request `GET /participants/{Type}/{ID}?currency=XYZ`
+        should be used, where `XYZ` is the requested currency.
       summary: Look up participant information
       tags:
         - participants
       operationId: ParticipantsSubIdByTypeAndID
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     put:
-      description: The callback `PUT /participants/{Type}/{ID}` (or `PUT /participants/{Type}/{ID}/{SubId}`) is used to inform the client of a successful result of the lookup, creation, or deletion of the FSP information related to the Party. If the FSP information is deleted, the fspId element should be empty; otherwise the element should include the FSP information for the Party.
+      description: >-
+        The callback `PUT /participants/{Type}/{ID}` (or `PUT
+        /participants/{Type}/{ID}/{SubId}`) is used to inform the client of a
+        successful result of the lookup, creation, or deletion of the FSP
+        information related to the Party. If the FSP information is deleted, the
+        fspId element should be empty; otherwise the element should include the
+        FSP information for the Party.
       summary: Return participant information
       tags:
         - participants
       operationId: ParticipantsSubIdByTypeAndID3
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Participant information returned.
@@ -315,69 +353,79 @@ paths:
             schema:
               $ref: "#/components/schemas/ParticipantsTypeIDPutResponse"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     delete:
-      description:
-        The HTTP request `DELETE /participants/{Type}/{ID}` (or `DELETE /participants/{Type}/{ID}/{SubId}`) is used to delete information in the server regarding the provided identity, defined by `{Type}` and `{ID}`) (for example, `DELETE /participants/MSISDN/123456789`), and optionally `{SubId}`. This HTTP request should support a query string to delete FSP information regarding a specific currency only. To delete a specific currency only, the HTTP request `DELETE /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is the requested currency.
+      description: >-
+        The HTTP request `DELETE /participants/{Type}/{ID}` (or `DELETE
+        /participants/{Type}/{ID}/{SubId}`) is used to delete information in the
+        server regarding the provided identity, defined by `{Type}` and `{ID}`)
+        (for example, `DELETE /participants/MSISDN/123456789`), and optionally
+        `{SubId}`. This HTTP request should support a query string to delete FSP
+        information regarding a specific currency only. To delete a specific
+        currency only, the HTTP request `DELETE
+        /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is
+        the requested currency.
 
 
-        **Note:** The Account Lookup System should verify that it is the Party’s current FSP that is deleting the FSP information.
+        **Note:** The Account Lookup System should verify that it is the Party’s
+        current FSP that is deleting the FSP information.
       summary: Delete participant information
       tags:
         - participants
       operationId: ParticipantsSubIdByTypeAndID2
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /participants/{Type}/{ID}/{SubId}/error:
     put:
-      description: If the server is unable to find, create or delete the associated FSP of the provided identity, or another processing error occurred, the error callback `PUT /participants/{Type}/{ID}/error` (or `PUT /participants/{Type}/{ID}/{SubId}/error`) is used.
+      description: >-
+        If the server is unable to find, create or delete the associated FSP of
+        the provided identity, or another processing error occurred, the error
+        callback `PUT /participants/{Type}/{ID}/error` (or `PUT
+        /participants/{Type}/{ID}/{SubId}/error`) is used.
       summary: Return participant information error
       tags:
         - participants
       operationId: ParticipantsSubIdErrorByTypeAndID
       parameters:
-        #Path
         - $ref: "#/components/parameters/Type"
         - $ref: "#/components/parameters/ID"
         - $ref: "#/components/parameters/SubId"
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
         - $ref: "#/components/parameters/Date"
@@ -396,33 +444,37 @@ paths:
             schema:
               $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /participants:
     post:
-      description: The HTTP request `POST /participants` is used to create information in the server regarding the provided list of identities. This request should be used for bulk creation of FSP information for more than one Party. The optional currency parameter should indicate that each provided Party supports the currency.
+      description: >-
+        The HTTP request `POST /participants` is used to create information in
+        the server regarding the provided list of identities. This request
+        should be used for bulk creation of FSP information for more than one
+        Party. The optional currency parameter should indicate that each
+        provided Party supports the currency.
       summary: Create bulk participant information
       tags:
         - participants
       operationId: Participants1
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
@@ -442,35 +494,35 @@ paths:
             schema:
               $ref: "#/components/schemas/ParticipantsPostRequest"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /participants/{ID}:
     put:
-      description: The callback `PUT /participants/{ID}` is used to inform the client of the result of the creation of the provided list of identities.
+      description: >-
+        The callback `PUT /participants/{ID}` is used to inform the client of
+        the result of the creation of the provided list of identities.
       summary: Return bulk participant information
       tags:
         - participants
       operationId: putParticipantsByID
       parameters:
-        #Path
         - $ref: "#/components/parameters/ID"
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
         - $ref: "#/components/parameters/Date"
@@ -489,35 +541,37 @@ paths:
             schema:
               $ref: "#/components/schemas/ParticipantsIDPutResponse"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /participants/{ID}/error:
     put:
-      description: If there is an error during FSP information creation in the server, the error callback `PUT /participants/{ID}/error` is used. The `{ID}` in the URI should contain the requestId that was used for the creation of the participant information.
+      description: >-
+        If there is an error during FSP information creation in the server, the
+        error callback `PUT /participants/{ID}/error` is used. The `{ID}` in the
+        URI should contain the requestId that was used for the creation of the
+        participant information.
       summary: Return bulk participant information error
       tags:
         - participants
       operationId: ParticipantsByIDAndError
       parameters:
-        #Path
         - $ref: "#/components/parameters/ID"
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
         - $ref: "#/components/parameters/Date"
@@ -536,32 +590,28 @@ paths:
             schema:
               $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
-
-  #Parties
   /parties/{Type}/{ID}:
     parameters:
-      #Path
       - $ref: "#/components/parameters/Type"
       - $ref: "#/components/parameters/ID"
-      #Headers
       - $ref: "#/components/parameters/Content-Type"
       - $ref: "#/components/parameters/Date"
       - $ref: "#/components/parameters/X-Forwarded-For"
@@ -572,41 +622,47 @@ paths:
       - $ref: "#/components/parameters/FSPIOP-URI"
       - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
-      description: The HTTP request `GET /parties/{Type}/{ID}` (or `GET /parties/{Type}/{ID}/{SubId}`) is used to look up information regarding the requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}` (for example, `GET /parties/MSISDN/123456789`, or `GET /parties/BUSINESS/shoecompany/employee1`).
+      description: >-
+        The HTTP request `GET /parties/{Type}/{ID}` (or `GET
+        /parties/{Type}/{ID}/{SubId}`) is used to look up information regarding
+        the requested Party, defined by `{Type}`, `{ID}` and optionally
+        `{SubId}` (for example, `GET /parties/MSISDN/123456789`, or `GET
+        /parties/BUSINESS/shoecompany/employee1`).
       summary: Look up party information
       tags:
         - parties
       operationId: PartiesByTypeAndID
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     put:
-      description: The callback `PUT /parties/{Type}/{ID}` (or `PUT /parties/{Type}/{ID}/{SubId}`) is used to inform the client of a successful result of the Party information lookup.
+      description: >-
+        The callback `PUT /parties/{Type}/{ID}` (or `PUT
+        /parties/{Type}/{ID}/{SubId}`) is used to inform the client of a
+        successful result of the Party information lookup.
       summary: Return party information
       tags:
         - parties
       operationId: PartiesByTypeAndID2
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Party information returned.
@@ -616,36 +672,38 @@ paths:
             schema:
               $ref: "#/components/schemas/PartiesTypeIDPutResponse"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /parties/{Type}/{ID}/error:
     put:
-      description: If the server is unable to find Party information of the provided identity, or another processing error occurred, the error callback `PUT /parties/{Type}/{ID}/error` (or `PUT /parties/{Type}/{ID}/{SubI}/error`) is used.
+      description: >-
+        If the server is unable to find Party information of the provided
+        identity, or another processing error occurred, the error callback `PUT
+        /parties/{Type}/{ID}/error` (or `PUT /parties/{Type}/{ID}/{SubI}/error`)
+        is used.
       summary: Return party information error
       tags:
         - parties
       operationId: PartiesErrorByTypeAndID
       parameters:
-        #Path
         - $ref: "#/components/parameters/Type"
         - $ref: "#/components/parameters/ID"
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
         - $ref: "#/components/parameters/Date"
@@ -664,31 +722,29 @@ paths:
             schema:
               $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /parties/{Type}/{ID}/{SubId}:
     parameters:
-      #Path
       - $ref: "#/components/parameters/Type"
       - $ref: "#/components/parameters/ID"
       - $ref: "#/components/parameters/SubId"
-      #Headers
       - $ref: "#/components/parameters/Content-Type"
       - $ref: "#/components/parameters/Date"
       - $ref: "#/components/parameters/X-Forwarded-For"
@@ -699,41 +755,47 @@ paths:
       - $ref: "#/components/parameters/FSPIOP-URI"
       - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
-      description: The HTTP request `GET /parties/{Type}/{ID}` (or `GET /parties/{Type}/{ID}/{SubId}`) is used to look up information regarding the requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}` (for example, `GET /parties/MSISDN/123456789`, or `GET /parties/BUSINESS/shoecompany/employee1`).
+      description: >-
+        The HTTP request `GET /parties/{Type}/{ID}` (or `GET
+        /parties/{Type}/{ID}/{SubId}`) is used to look up information regarding
+        the requested Party, defined by `{Type}`, `{ID}` and optionally
+        `{SubId}` (for example, `GET /parties/MSISDN/123456789`, or `GET
+        /parties/BUSINESS/shoecompany/employee1`).
       summary: Look up party information
       tags:
         - parties
       operationId: PartiesSubIdByTypeAndID
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     put:
-      description: The callback `PUT /parties/{Type}/{ID}` (or `PUT /parties/{Type}/{ID}/{SubId}`) is used to inform the client of a successful result of the Party information lookup.
+      description: >-
+        The callback `PUT /parties/{Type}/{ID}` (or `PUT
+        /parties/{Type}/{ID}/{SubId}`) is used to inform the client of a
+        successful result of the Party information lookup.
       summary: Return party information
       tags:
         - parties
       operationId: PartiesSubIdByTypeAndIDPut
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Party information returned.
@@ -743,37 +805,39 @@ paths:
             schema:
               $ref: "#/components/schemas/PartiesTypeIDPutResponse"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /parties/{Type}/{ID}/{SubId}/error:
     put:
-      description: If the server is unable to find Party information of the provided identity, or another processing error occurred, the error callback `PUT /parties/{Type}/{ID}/error` (or `PUT /parties/{Type}/{ID}/{SubId}/error`) is used.
+      description: >-
+        If the server is unable to find Party information of the provided
+        identity, or another processing error occurred, the error callback `PUT
+        /parties/{Type}/{ID}/error` (or `PUT
+        /parties/{Type}/{ID}/{SubId}/error`) is used.
       summary: Return party information error
       tags:
         - parties
       operationId: PartiesSubIdErrorByTypeAndID
       parameters:
-        #Path
         - $ref: "#/components/parameters/Type"
         - $ref: "#/components/parameters/ID"
         - $ref: "#/components/parameters/SubId"
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
         - $ref: "#/components/parameters/Date"
@@ -792,35 +856,35 @@ paths:
             schema:
               $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
-
-  #Transaction requests
   /transactionRequests:
     post:
-      description: The HTTP request `POST /transactionRequests` is used to request the creation of a transaction request for the provided financial transaction in the server.
+      description: >-
+        The HTTP request `POST /transactionRequests` is used to request the
+        creation of a transaction request for the provided financial transaction
+        in the server.
       summary: Perform transaction request
       tags:
         - transactionRequests
       operationId: TransactionRequests
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
@@ -840,29 +904,27 @@ paths:
             schema:
               $ref: "#/components/schemas/TransactionRequestsPostRequest"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /transactionRequests/{ID}:
     parameters:
-      #Path
       - $ref: "#/components/parameters/ID"
-      #Headers
       - $ref: "#/components/parameters/Content-Type"
       - $ref: "#/components/parameters/Date"
       - $ref: "#/components/parameters/X-Forwarded-For"
@@ -873,41 +935,48 @@ paths:
       - $ref: "#/components/parameters/FSPIOP-URI"
       - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
-      description: The HTTP request `GET /transactionRequests/{ID}` is used to get information regarding a transaction request created or requested earlier. The `{ID}` in the URI should contain the `transactionRequestId` that was used for the creation of the transaction request.
+      description: >-
+        The HTTP request `GET /transactionRequests/{ID}` is used to get
+        information regarding a transaction request created or requested
+        earlier. The `{ID}` in the URI should contain the `transactionRequestId`
+        that was used for the creation of the transaction request.
       summary: Retrieve transaction request information
       tags:
         - transactionRequests
       operationId: TransactionRequestsByID
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     put:
-      description: The callback `PUT /transactionRequests/{ID}` is used to inform the client of a requested or created transaction request. The `{ID}` in the URI should contain the `transactionRequestId` that was used for the creation of the transaction request, or the `{ID}` that was used in the `GET /transactionRequests/{ID}`.
+      description: >-
+        The callback `PUT /transactionRequests/{ID}` is used to inform the
+        client of a requested or created transaction request. The `{ID}` in the
+        URI should contain the `transactionRequestId` that was used for the
+        creation of the transaction request, or the `{ID}` that was used in the
+        `GET /transactionRequests/{ID}`.
       summary: Return transaction request information
       tags:
         - transactionRequests
       operationId: TransactionRequestsByIDPut
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Transaction request information returned.
@@ -917,35 +986,39 @@ paths:
             schema:
               $ref: "#/components/schemas/TransactionRequestsIDPutResponse"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /transactionRequests/{ID}/error:
     put:
-      description: If the server is unable to find or create a transaction request, or another processing error occurs, the error callback `PUT /transactionRequests/{ID}/error` is used. The `{ID}` in the URI should contain the `transactionRequestId` that was used for the creation of the transaction request, or the `{ID}` that was used in the `GET /transactionRequests/{ID}`.
+      description: >-
+        If the server is unable to find or create a transaction request, or
+        another processing error occurs, the error callback `PUT
+        /transactionRequests/{ID}/error` is used. The `{ID}` in the URI should
+        contain the `transactionRequestId` that was used for the creation of the
+        transaction request, or the `{ID}` that was used in the `GET
+        /transactionRequests/{ID}`.
       summary: Return transaction request information error
       tags:
         - transactionRequests
       operationId: TransactionRequestsErrorByID
       parameters:
-        #Path
         - $ref: "#/components/parameters/ID"
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
         - $ref: "#/components/parameters/Date"
@@ -964,35 +1037,34 @@ paths:
             schema:
               $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
-
-  #Quotes
   /quotes:
     post:
-      description: The HTTP request `POST /quotes` is used to request the creation of a quote for the provided financial transaction in the server.
+      description: >-
+        The HTTP request `POST /quotes` is used to request the creation of a
+        quote for the provided financial transaction in the server.
       summary: Calculate quote
       tags:
         - quotes
       operationId: Quotes
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
@@ -1012,29 +1084,27 @@ paths:
             schema:
               $ref: "#/components/schemas/QuotesPostRequest"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /quotes/{ID}:
     parameters:
-      #Path
       - $ref: "#/components/parameters/ID"
-      #Headers
       - $ref: "#/components/parameters/Content-Type"
       - $ref: "#/components/parameters/Date"
       - $ref: "#/components/parameters/X-Forwarded-For"
@@ -1045,41 +1115,46 @@ paths:
       - $ref: "#/components/parameters/FSPIOP-URI"
       - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
-      description: The HTTP request `GET /quotes/{ID}` is used to get information regarding a quote created or requested earlier. The `{ID}` in the URI should contain the `quoteId` that was used for the creation of the quote.
+      description: >-
+        The HTTP request `GET /quotes/{ID}` is used to get information regarding
+        a quote created or requested earlier. The `{ID}` in the URI should
+        contain the `quoteId` that was used for the creation of the quote.
       summary: Retrieve quote information
       tags:
         - quotes
       operationId: QuotesByID
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     put:
-      description: The callback `PUT /quotes/{ID}` is used to inform the client of a requested or created quote. The `{ID}` in the URI should contain the `quoteId` that was used for the creation of the quote, or the `{ID}` that was used in the `GET /quotes/{ID}` request.
+      description: >-
+        The callback `PUT /quotes/{ID}` is used to inform the client of a
+        requested or created quote. The `{ID}` in the URI should contain the
+        `quoteId` that was used for the creation of the quote, or the `{ID}`
+        that was used in the `GET /quotes/{ID}` request.
       summary: Return quote information
       tags:
         - quotes
       operationId: QuotesByID1
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Quote information returned.
@@ -1089,35 +1164,38 @@ paths:
             schema:
               $ref: "#/components/schemas/QuotesIDPutResponse"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /quotes/{ID}/error:
     put:
-      description: If the server is unable to find or create a quote, or some other processing error occurs, the error callback `PUT /quotes/{ID}/error` is used. The `{ID}` in the URI should contain the `quoteId` that was used for the creation of the quote, or the `{ID}` that was used in the `GET /quotes/{ID}` request.
+      description: >-
+        If the server is unable to find or create a quote, or some other
+        processing error occurs, the error callback `PUT /quotes/{ID}/error` is
+        used. The `{ID}` in the URI should contain the `quoteId` that was used
+        for the creation of the quote, or the `{ID}` that was used in the `GET
+        /quotes/{ID}` request.
       summary: Return quote information error
       tags:
         - quotes
       operationId: QuotesByIDAndError
       parameters:
-        #Path
         - $ref: "#/components/parameters/ID"
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
         - $ref: "#/components/parameters/Date"
@@ -1136,31 +1214,27 @@ paths:
             schema:
               $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
-
-  #Authorizations
   /authorizations/{ID}:
     parameters:
-      #Path
       - $ref: "#/components/parameters/ID"
-      #Headers
       - $ref: "#/components/parameters/Content-Type"
       - $ref: "#/components/parameters/Date"
       - $ref: "#/components/parameters/X-Forwarded-For"
@@ -1171,60 +1245,79 @@ paths:
       - $ref: "#/components/parameters/FSPIOP-URI"
       - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
-      description:
-        The HTTP request `GET /authorizations/{ID}` is used to request the Payer to enter the applicable credentials in the Payee FSP system. The `{ID}` in the URI should contain the `transactionRequestID`, received from the `POST /transactionRequests` service earlier in the process. This request requires a query string to be included in the URI, with the following key-value pairs*:*
+      description: >-
+        The HTTP request `GET /authorizations/{ID}` is used to request the Payer
+        to enter the applicable credentials in the Payee FSP system. The `{ID}`
+        in the URI should contain the `transactionRequestID`, received from the
+        `POST /transactionRequests` service earlier in the process. This request
+        requires a query string to be included in the URI, with the following
+        key-value pairs*:*
 
 
-        - `authenticationType={Type}`, where `{Type}` value is a valid authentication type from the enumeration `AuthenticationType`.
+        - `authenticationType={Type}`, where `{Type}` value is a valid
+        authentication type from the enumeration `AuthenticationType`.
 
 
-        - `retriesLeft=={NrOfRetries}`, where `{NrOfRetries}` is the number of retries left before the financial transaction is rejected. `{NrOfRetries}` must be expressed in the form of the data type `Integer`. `retriesLeft=1` means that this is the last retry before the financial transaction is rejected.
+        - `retriesLeft=={NrOfRetries}`, where `{NrOfRetries}` is the number of
+        retries left before the financial transaction is rejected.
+        `{NrOfRetries}` must be expressed in the form of the data type
+        `Integer`. `retriesLeft=1` means that this is the last retry before the
+        financial transaction is rejected.
 
 
-        - `amount={Amount}`, where `{Amount}` is the transaction amount that will be withdrawn from the Payer’s account. `{Amount}` must be expressed in the form of the data type `Amount`.
+        - `amount={Amount}`, where `{Amount}` is the transaction amount that
+        will be withdrawn from the Payer’s account. `{Amount}` must be expressed
+        in the form of the data type `Amount`.
 
 
-        - `currency={Currency}`, where `{Currency}` is the transaction currency for the amount that will be withdrawn from the Payer’s account. The `{Currency}` value must be expressed in the form of the enumeration `CurrencyCode`.
+        - `currency={Currency}`, where `{Currency}` is the transaction currency
+        for the amount that will be withdrawn from the Payer’s account. The
+        `{Currency}` value must be expressed in the form of the enumeration
+        `CurrencyCode`.
 
 
-        The following is an example URI containing all the required key-value pairs in the query string*:*
+        The following is an example URI containing all the required key-value
+        pairs in the query string*:*
 
 
-        `GET /authorization/3d492671-b7af-4f3f-88de-76169b1bdf88?authenticationType=OTP&retriesLeft=2&amount=102&currency=USD`
+        `GET
+        /authorization/3d492671-b7af-4f3f-88de-76169b1bdf88?authenticationType=OTP&retriesLeft=2&amount=102&currency=USD`
       summary: Perform authorization
       tags:
         - authorizations
       operationId: AuthorizationsByIDGet
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     put:
-      description: The callback `PUT /authorizations/{ID}` is used to inform the client of the result of a previously-requested authorization. The `{ID}` in the URI should contain the `{ID}` that was used in the `GET /authorizations/{ID}` request.
+      description: >-
+        The callback `PUT /authorizations/{ID}` is used to inform the client of
+        the result of a previously-requested authorization. The `{ID}` in the
+        URI should contain the `{ID}` that was used in the `GET
+        /authorizations/{ID}` request.
       summary: Return authorization result
       tags:
         - authorizations
       operationId: AuthorizationsByIDPut
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Authorization result returned.
@@ -1234,35 +1327,37 @@ paths:
             schema:
               $ref: "#/components/schemas/AuthorizationsIDPutResponse"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /authorizations/{ID}/error:
     put:
-      description: If the server is unable to find the transaction request, or another processing error occurs, the error callback `PUT /authorizations/{ID}/error` is used. The `{ID}` in the URI should contain the `{ID}` that was used in the `GET /authorizations/{ID}`.
+      description: >-
+        If the server is unable to find the transaction request, or another
+        processing error occurs, the error callback `PUT
+        /authorizations/{ID}/error` is used. The `{ID}` in the URI should
+        contain the `{ID}` that was used in the `GET /authorizations/{ID}`.
       summary: Return authorization error
       tags:
         - authorizations
       operationId: AuthorizationsByIDAndError
       parameters:
-        #Path
         - $ref: "#/components/parameters/ID"
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
         - $ref: "#/components/parameters/Date"
@@ -1281,35 +1376,35 @@ paths:
             schema:
               $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
-
-  #Transfers
   /transfers:
     post:
-      description: The HTTP request `POST /transfers` is used to request the creation of a transfer for the next ledger, and a financial transaction for the Payee FSP.
+      description: >-
+        The HTTP request `POST /transfers` is used to request the creation of a
+        transfer for the next ledger, and a financial transaction for the Payee
+        FSP.
       summary: Perform transfer
       tags:
         - transfers
       operationId: transfers
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
@@ -1329,29 +1424,27 @@ paths:
             schema:
               $ref: "#/components/schemas/TransfersPostRequest"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /transfers/{ID}:
     parameters:
-      #Path
       - $ref: "#/components/parameters/ID"
-      #Headers
       - $ref: "#/components/parameters/Content-Type"
       - $ref: "#/components/parameters/Date"
       - $ref: "#/components/parameters/X-Forwarded-For"
@@ -1362,41 +1455,49 @@ paths:
       - $ref: "#/components/parameters/FSPIOP-URI"
       - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
-      description: The HTTP request `GET /transfers/{ID}` is used to get information regarding a transfer created or requested earlier. The `{ID}` in the URI should contain the `transferId` that was used for the creation of the transfer.
+      description: >-
+        The HTTP request `GET /transfers/{ID}` is used to get information
+        regarding a transfer created or requested earlier. The `{ID}` in the URI
+        should contain the `transferId` that was used for the creation of the
+        transfer.
       summary: Retrieve transfer information
       tags:
         - transfers
       operationId: TransfersByIDGet
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     patch:
-      description: The HTTP request PATCH /transfers/<ID> is used by a Switch to update the state of a previously reserved transfer, if the Payee FSP has requested a commit notification when the Switch has completed processing of the transfer. The <ID> in the URI should contain the transferId that was used for the creation of the transfer. Please note that this request does not generate a callback.
+      description: >-
+        The HTTP request PATCH /transfers/<ID> is used by a Switch to update the
+        state of a previously reserved transfer, if the Payee FSP has requested
+        a commit notification when the Switch has completed processing of the
+        transfer. The <ID> in the URI should contain the transferId that was
+        used for the creation of the transfer. Please note that this request
+        does not generate a callback.
       summary: Return transfer information
       tags:
         - transfers
       operationId: TransfersByIDPatch
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Transfer notification upon completion.
@@ -1406,32 +1507,35 @@ paths:
             schema:
               $ref: "#/components/schemas/TransfersIDPatchResponse"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     put:
-      description: The callback `PUT /transfers/{ID}` is used to inform the client of a requested or created transfer. The `{ID}` in the URI should contain the `transferId` that was used for the creation of the transfer, or the `{ID}` that was used in the `GET /transfers/{ID}` request.
+      description: >-
+        The callback `PUT /transfers/{ID}` is used to inform the client of a
+        requested or created transfer. The `{ID}` in the URI should contain the
+        `transferId` that was used for the creation of the transfer, or the
+        `{ID}` that was used in the `GET /transfers/{ID}` request.
       summary: Return transfer information
       tags:
         - transfers
       operationId: TransfersByIDPut
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Transfer information returned.
@@ -1441,35 +1545,38 @@ paths:
             schema:
               $ref: "#/components/schemas/TransfersIDPutResponse"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /transfers/{ID}/error:
     put:
-      description: If the server is unable to find or create a transfer, or another processing error occurs, the error callback `PUT /transfers/{ID}/error` is used. The `{ID}` in the URI should contain the `transferId` that was used for the creation of the transfer, or the `{ID}` that was used in the `GET /transfers/{ID}`.
+      description: >-
+        If the server is unable to find or create a transfer, or another
+        processing error occurs, the error callback `PUT /transfers/{ID}/error`
+        is used. The `{ID}` in the URI should contain the `transferId` that was
+        used for the creation of the transfer, or the `{ID}` that was used in
+        the `GET /transfers/{ID}`.
       summary: Return transfer information error
       tags:
         - transfers
       operationId: TransfersByIDAndError
       parameters:
-        #Path
         - $ref: "#/components/parameters/ID"
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
         - $ref: "#/components/parameters/Date"
@@ -1488,30 +1595,27 @@ paths:
             schema:
               $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
-
-  #Transactions
   /transactions/{ID}:
     parameters:
       - $ref: "#/components/parameters/ID"
-      #Headers
       - $ref: "#/components/parameters/Content-Type"
       - $ref: "#/components/parameters/Date"
       - $ref: "#/components/parameters/X-Forwarded-For"
@@ -1522,41 +1626,47 @@ paths:
       - $ref: "#/components/parameters/FSPIOP-URI"
       - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
-      description: The HTTP request `GET /transactions/{ID}` is used to get transaction information regarding a financial transaction created earlier. The `{ID}` in the URI should contain the `transactionId` that was used for the creation of the quote, as the transaction is created as part of another process (the transfer process).
+      description: >-
+        The HTTP request `GET /transactions/{ID}` is used to get transaction
+        information regarding a financial transaction created earlier. The
+        `{ID}` in the URI should contain the `transactionId` that was used for
+        the creation of the quote, as the transaction is created as part of
+        another process (the transfer process).
       summary: Retrieve transaction information
       tags:
         - transactions
       operationId: TransactionsByID
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     put:
-      description: The callback `PUT /transactions/{ID}` is used to inform the client of a requested transaction. The `{ID}` in the URI should contain the `{ID}` that was used in the `GET /transactions/{ID}` request.
+      description: >-
+        The callback `PUT /transactions/{ID}` is used to inform the client of a
+        requested transaction. The `{ID}` in the URI should contain the `{ID}`
+        that was used in the `GET /transactions/{ID}` request.
       summary: Return transaction information
       tags:
         - transactions
       operationId: TransactionsByID1
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Transaction information returned.
@@ -1566,35 +1676,37 @@ paths:
             schema:
               $ref: "#/components/schemas/TransactionsIDPutResponse"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /transactions/{ID}/error:
     put:
-      description: If the server is unable to find or create a transaction, or another processing error occurs, the error callback `PUT /transactions/{ID}/error` is used. The `{ID}` in the URI should contain the `{ID}` that was used in the `GET /transactions/{ID}` request.
+      description: >-
+        If the server is unable to find or create a transaction, or another
+        processing error occurs, the error callback `PUT
+        /transactions/{ID}/error` is used. The `{ID}` in the URI should contain
+        the `{ID}` that was used in the `GET /transactions/{ID}` request.
       summary: Return transaction information error
       tags:
         - transactions
       operationId: TransactionsErrorByID
       parameters:
-        #Path
         - $ref: "#/components/parameters/ID"
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
         - $ref: "#/components/parameters/Date"
@@ -1613,35 +1725,34 @@ paths:
             schema:
               $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
-
-  #Bulk Quotes
   /bulkQuotes:
     post:
-      description: The HTTP request `POST /bulkQuotes` is used to request the creation of a bulk quote for the provided financial transactions in the server.
+      description: >-
+        The HTTP request `POST /bulkQuotes` is used to request the creation of a
+        bulk quote for the provided financial transactions in the server.
       summary: Calculate bulk quote
       tags:
         - bulkQuotes
       operationId: BulkQuotes
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
@@ -1661,29 +1772,27 @@ paths:
             schema:
               $ref: "#/components/schemas/BulkQuotesPostRequest"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /bulkQuotes/{ID}:
     parameters:
-      #Path
       - $ref: "#/components/parameters/ID"
-      #Headers
       - $ref: "#/components/parameters/Content-Type"
       - $ref: "#/components/parameters/Date"
       - $ref: "#/components/parameters/X-Forwarded-For"
@@ -1694,41 +1803,47 @@ paths:
       - $ref: "#/components/parameters/FSPIOP-URI"
       - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
-      description: The HTTP request `GET /bulkQuotes/{ID}` is used to get information regarding a bulk quote created or requested earlier. The `{ID}` in the URI should contain the `bulkQuoteId` that was used for the creation of the bulk quote.
+      description: >-
+        The HTTP request `GET /bulkQuotes/{ID}` is used to get information
+        regarding a bulk quote created or requested earlier. The `{ID}` in the
+        URI should contain the `bulkQuoteId` that was used for the creation of
+        the bulk quote.
       summary: Retrieve bulk quote information
       tags:
         - bulkQuotes
       operationId: BulkQuotesByID
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     put:
-      description: The callback `PUT /bulkQuotes/{ID}` is used to inform the client of a requested or created bulk quote. The `{ID}` in the URI should contain the `bulkQuoteId` that was used for the creation of the bulk quote, or the `{ID}` that was used in the `GET /bulkQuotes/{ID}` request.
+      description: >-
+        The callback `PUT /bulkQuotes/{ID}` is used to inform the client of a
+        requested or created bulk quote. The `{ID}` in the URI should contain
+        the `bulkQuoteId` that was used for the creation of the bulk quote, or
+        the `{ID}` that was used in the `GET /bulkQuotes/{ID}` request.
       summary: Return bulk quote information
       tags:
         - bulkQuotes
       operationId: BulkQuotesByID1
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Bulk quote information returned.
@@ -1738,35 +1853,38 @@ paths:
             schema:
               $ref: "#/components/schemas/BulkQuotesIDPutResponse"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /bulkQuotes/{ID}/error:
     put:
-      description: If the server is unable to find or create a bulk quote, or another processing error occurs, the error callback `PUT /bulkQuotes/{ID}/error` is used. The `{ID}` in the URI should contain the `bulkQuoteId` that was used for the creation of the bulk quote, or the `{ID}` that was used in the `GET /bulkQuotes/{ID}` request.
+      description: >-
+        If the server is unable to find or create a bulk quote, or another
+        processing error occurs, the error callback `PUT /bulkQuotes/{ID}/error`
+        is used. The `{ID}` in the URI should contain the `bulkQuoteId` that was
+        used for the creation of the bulk quote, or the `{ID}` that was used in
+        the `GET /bulkQuotes/{ID}` request.
       summary: Return bulk quote information error
       tags:
         - bulkQuotes
       operationId: BulkQuotesErrorByID
       parameters:
-        #Path
         - $ref: "#/components/parameters/ID"
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
         - $ref: "#/components/parameters/Date"
@@ -1785,35 +1903,34 @@ paths:
             schema:
               $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
-
-  #Bulk transfers
   /bulkTransfers:
     post:
-      description: The HTTP request `POST /bulkTransfers` is used to request the creation of a bulk transfer in the server.
+      description: >-
+        The HTTP request `POST /bulkTransfers` is used to request the creation
+        of a bulk transfer in the server.
       summary: Perform bulk transfer
       tags:
         - bulkTransfers
       operationId: BulkTransfers
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
@@ -1833,29 +1950,27 @@ paths:
             schema:
               $ref: "#/components/schemas/BulkTransfersPostRequest"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /bulkTransfers/{ID}:
     parameters:
-      #Path
       - $ref: "#/components/parameters/ID"
-      #Headers
       - $ref: "#/components/parameters/Content-Type"
       - $ref: "#/components/parameters/Date"
       - $ref: "#/components/parameters/X-Forwarded-For"
@@ -1866,41 +1981,48 @@ paths:
       - $ref: "#/components/parameters/FSPIOP-URI"
       - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
-      description: The HTTP request `GET /bulkTransfers/{ID}` is used to get information regarding a bulk transfer created or requested earlier. The `{ID}` in the URI should contain the `bulkTransferId` that was used for the creation of the bulk transfer.
+      description: >-
+        The HTTP request `GET /bulkTransfers/{ID}` is used to get information
+        regarding a bulk transfer created or requested earlier. The `{ID}` in
+        the URI should contain the `bulkTransferId` that was used for the
+        creation of the bulk transfer.
       summary: Retrieve bulk transfer information
       tags:
         - bulkTransfers
       operationId: BulkTransferByID
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Accept"
       responses:
-        202:
+        "202":
           $ref: "#/components/responses/202"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
     put:
-      description: The callback `PUT /bulkTransfers/{ID}` is used to inform the client of a requested or created bulk transfer. The `{ID}` in the URI should contain the `bulkTransferId` that was used for the creation of the bulk transfer (`POST /bulkTransfers`), or the `{ID}` that was used in the `GET /bulkTransfers/{ID}` request.
+      description: >-
+        The callback `PUT /bulkTransfers/{ID}` is used to inform the client of a
+        requested or created bulk transfer. The `{ID}` in the URI should contain
+        the `bulkTransferId` that was used for the creation of the bulk transfer
+        (`POST /bulkTransfers`), or the `{ID}` that was used in the `GET
+        /bulkTransfers/{ID}` request.
       summary: Return bulk transfer information
       tags:
         - bulkTransfers
       operationId: BulkTransfersByIDPut
       parameters:
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Bulk transfer information returned.
@@ -1910,35 +2032,39 @@ paths:
             schema:
               $ref: "#/components/schemas/BulkTransfersIDPutResponse"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
   /bulkTransfers/{ID}/error:
     put:
-      description: If the server is unable to find or create a bulk transfer, or another processing error occurs, the error callback `PUT /bulkTransfers/{ID}/error` is used. The `{ID}` in the URI should contain the `bulkTransferId` that was used for the creation of the bulk transfer (`POST /bulkTransfers`), or the `{ID}` that was used in the `GET /bulkTransfers/{ID}` request.
+      description: >-
+        If the server is unable to find or create a bulk transfer, or another
+        processing error occurs, the error callback `PUT
+        /bulkTransfers/{ID}/error` is used. The `{ID}` in the URI should contain
+        the `bulkTransferId` that was used for the creation of the bulk transfer
+        (`POST /bulkTransfers`), or the `{ID}` that was used in the `GET
+        /bulkTransfers/{ID}` request.
       summary: Return bulk transfer information error
       tags:
         - bulkTransfers
       operationId: BulkTransfersErrorByID
       parameters:
-        #Path
         - $ref: "#/components/parameters/ID"
-        #Headers
         - $ref: "#/components/parameters/Content-Length"
         - $ref: "#/components/parameters/Content-Type"
         - $ref: "#/components/parameters/Date"
@@ -1957,63 +2083,88 @@ paths:
             schema:
               $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        200:
+        "200":
           $ref: "#/components/responses/200"
-        400:
+        "400":
           $ref: "#/components/responses/400"
-        401:
+        "401":
           $ref: "#/components/responses/401"
-        403:
+        "403":
           $ref: "#/components/responses/403"
-        404:
+        "404":
           $ref: "#/components/responses/404"
-        405:
+        "405":
           $ref: "#/components/responses/405"
-        406:
+        "406":
           $ref: "#/components/responses/406"
-        501:
+        "501":
           $ref: "#/components/responses/501"
-        503:
+        "503":
           $ref: "#/components/responses/503"
-
 components:
   schemas:
-    #Element definitions
     Amount:
       title: Amount
       type: string
       pattern: ^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$
-      description: The API data type Amount is a JSON String in a canonical format that is restricted by a regular expression for interoperability reasons. This pattern does not allow any trailing zeroes at all, but allows an amount without a minor currency unit. It also only allows four digits in the minor currency unit; a negative value is not allowed. Using more than 18 digits in the major currency unit is not allowed.
+      description: >-
+        The API data type Amount is a JSON String in a canonical format that is
+        restricted by a regular expression for interoperability reasons. This
+        pattern does not allow any trailing zeroes at all, but allows an amount
+        without a minor currency unit. It also only allows four digits in the
+        minor currency unit; a negative value is not allowed. Using more than 18
+        digits in the major currency unit is not allowed.
+      example: "123.45"
     AmountType:
       title: AmountType
       type: string
       enum:
         - SEND
         - RECEIVE
-      description: Below are the allowed values for the enumeration AmountType.
+      description: >-
+        Below are the allowed values for the enumeration AmountType.
 
-        - SEND - Amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees.
+        - SEND - Amount the Payer would like to send, that is, the amount that
+        should be withdrawn from the Payer account including any fees.
 
-        - RECEIVE - Amount the Payer would like the Payee to receive, that is, the amount that should be sent to the receiver exclusive of any fees.
+        - RECEIVE - Amount the Payer would like the Payee to receive, that is,
+        the amount that should be sent to the receiver exclusive of any fees.
+      example: RECEIVE
+    AuthenticationInfo:
+      title: AuthenticationInfo
+      type: object
+      description: Data model for the complex type AuthenticationInfo.
+      properties:
+        authentication:
+          $ref: "#/components/schemas/AuthenticationType"
+        authenticationValue:
+          $ref: "#/components/schemas/AuthenticationValue"
+      required:
+        - authentication
+        - authenticationValue
     AuthenticationType:
       title: AuthenticationType
       type: string
       enum:
         - OTP
         - QRCODE
-      description:
+        - U2F
+      description: |-
         Below are the allowed values for the enumeration AuthenticationType.
-
         - OTP - One-time password generated by the Payer FSP.
-
         - QRCODE - QR code used as One Time Password.
+        - U2F - U2F is a new addition isolated to Thirdparty stream.
+      example: OTP
     AuthenticationValue:
       title: AuthenticationValue
-      oneOf:
+      anyOf:
         - $ref: "#/components/schemas/OtpValue"
         - $ref: "#/components/schemas/QRCODE"
+        - $ref: "#/components/schemas/U2FPinValue"
       pattern: ^\d{3,10}$|^\S{1,64}$
-      description: Contains the authentication value. The format depends on the authentication type used in the AuthenticationInfo complex type.
+      description: >-
+        Contains the authentication value. The format depends on the
+        authentication type used in the AuthenticationInfo complex type.
     AuthorizationResponse:
       title: AuthorizationResponse
       type: string
@@ -2021,26 +2172,95 @@ components:
         - ENTERED
         - REJECTED
         - RESEND
-      description: Below are the allowed values for the enumeration.
-
+      description: |-
+        Below are the allowed values for the enumeration.
         - ENTERED - Consumer entered the authentication value.
-
         - REJECTED - Consumer rejected the transaction.
-
         - RESEND - Consumer requested to resend the authentication value.
+      example: ENTERED
+    AuthorizationsIDPutResponse:
+      title: AuthorizationsIDPutResponse
+      type: object
+      description: The object sent in the PUT /authorizations/{ID} callback.
+      properties:
+        authenticationInfo:
+          $ref: "#/components/schemas/AuthenticationInfo"
+        responseType:
+          $ref: "#/components/schemas/AuthorizationResponse"
+      required:
+        - responseType
     BalanceOfPayments:
       title: BalanceOfPayments
       type: string
       pattern: ^[1-9]\d{2}$
-      description: (BopCode) The API data type [BopCode](https://www.imf.org/external/np/sta/bopcode/) is a JSON String of 3 characters, consisting of digits only. Negative numbers are not allowed. A leading zero is not allowed.
+      description: >-
+        (BopCode) The API data type
+        [BopCode](https://www.imf.org/external/np/sta/bopcode/) is a JSON String
+        of 3 characters, consisting of digits only. Negative numbers are not
+        allowed. A leading zero is not allowed.
+      example: "123"
     BinaryString:
       type: string
       pattern: ^[A-Za-z0-9-_]+[=]{0,2}$
-      description: The API data type BinaryString is a JSON String. The string is a base64url  encoding of a string of raw bytes, where padding (character ‘=’) is added at the end of the data if needed to ensure that the string is a multiple of 4 characters. The length restriction indicates the allowed number of characters.
+      description: >-
+        The API data type BinaryString is a JSON String. The string is a
+        base64url  encoding of a string of raw bytes, where padding (character
+        ‘=’) is added at the end of the data if needed to ensure that the string
+        is a multiple of 4 characters. The length restriction indicates the
+        allowed number of characters.
     BinaryString32:
       type: string
       pattern: ^[A-Za-z0-9-_]{43}$
-      description: The API data type BinaryString32 is a fixed size version of the API data type BinaryString, where the raw underlying data is always of 32 bytes. The data type BinaryString32 should not use a padding character as the size of the underlying data is fixed.
+      description: >-
+        The API data type BinaryString32 is a fixed size version of the API data
+        type BinaryString, where the raw underlying data is always of 32 bytes.
+        The data type BinaryString32 should not use a padding character as the
+        size of the underlying data is fixed.
+    BulkQuotesIDPutResponse:
+      title: BulkQuotesIDPutResponse
+      type: object
+      description: The object sent in the PUT /bulkQuotes/{ID} callback.
+      properties:
+        individualQuoteResults:
+          type: array
+          maxItems: 1000
+          items:
+            $ref: "#/components/schemas/IndividualQuoteResult"
+          description: >-
+            Fees for each individual transaction, if any of them are charged per
+            transaction.
+        expiration:
+          $ref: "#/components/schemas/DateTime"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - expiration
+    BulkQuotesPostRequest:
+      title: BulkQuotesPostRequest
+      type: object
+      description: The object sent in the POST /bulkQuotes request.
+      properties:
+        bulkQuoteId:
+          $ref: "#/components/schemas/CorrelationId"
+        payer:
+          $ref: "#/components/schemas/Party"
+        geoCode:
+          $ref: "#/components/schemas/GeoCode"
+        expiration:
+          $ref: "#/components/schemas/DateTime"
+        individualQuotes:
+          type: array
+          minItems: 1
+          maxItems: 1000
+          items:
+            $ref: "#/components/schemas/IndividualQuote"
+          description: List of quotes elements.
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - bulkQuoteId
+        - payer
+        - individualQuotes
     BulkTransferState:
       title: BulkTransactionState
       type: string
@@ -2051,9 +2271,11 @@ components:
         - PROCESSING
         - COMPLETED
         - REJECTED
-      description: Below are the allowed values for the enumeration.
+      description: >-
+        Below are the allowed values for the enumeration.
 
-        - RECEIVED - Payee FSP has received the bulk transfer from the Payer FSP.
+        - RECEIVED - Payee FSP has received the bulk transfer from the Payer
+        FSP.
 
         - PENDING - Payee FSP has validated the bulk transfer.
 
@@ -2064,19 +2286,83 @@ components:
         - COMPLETED - Payee FSP has completed transfer of funds to the Payees.
 
         - REJECTED - Payee FSP has rejected to process the bulk transfer.
+      example: RECEIVED
+    BulkTransfersIDPutResponse:
+      title: BulkTransfersIDPutResponse
+      type: object
+      description: The object sent in the PUT /bulkTransfers/{ID} callback.
+      properties:
+        completedTimestamp:
+          $ref: "#/components/schemas/DateTime"
+        individualTransferResults:
+          type: array
+          maxItems: 1000
+          items:
+            $ref: "#/components/schemas/IndividualTransferResult"
+          description: List of IndividualTransferResult elements.
+        bulkTransferState:
+          $ref: "#/components/schemas/BulkTransferState"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - bulkTransferState
+    BulkTransfersPostRequest:
+      title: BulkTransfersPostRequest
+      type: object
+      description: The object sent in the POST /bulkTransfers request.
+      properties:
+        bulkTransferId:
+          $ref: "#/components/schemas/CorrelationId"
+        bulkQuoteId:
+          $ref: "#/components/schemas/CorrelationId"
+        payerFsp:
+          $ref: "#/components/schemas/FspId"
+        payeeFsp:
+          $ref: "#/components/schemas/FspId"
+        individualTransfers:
+          type: array
+          minItems: 1
+          maxItems: 1000
+          items:
+            $ref: "#/components/schemas/IndividualTransfer"
+          description: List of IndividualTransfer elements.
+        expiration:
+          $ref: "#/components/schemas/DateTime"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - bulkTransferId
+        - bulkQuoteId
+        - payerFsp
+        - payeeFsp
+        - individualTransfers
+        - expiration
     Code:
       title: Code
       type: string
       pattern: ^[0-9a-zA-Z]{4,32}$
       description: Any code/token returned by the Payee FSP (TokenCode Type).
+      example: Test-Code
     CorrelationId:
       title: CorrelationId
       type: string
-      pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
-      description: Identifier that correlates all messages of the same sequence. The API data type UUID (Universally Unique Identifier) is a JSON String in canonical format, conforming to [RFC 4122](https://tools.ietf.org/html/rfc4122), that is restricted by a regular expression for interoperability reasons. A UUID is always 36 characters long, 32 hexadecimal symbols and 4 dashes (‘-‘).
+      pattern: >-
+        ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
+      description: >-
+        Identifier that correlates all messages of the same sequence. The API
+        data type UUID (Universally Unique Identifier) is a JSON String in
+        canonical format, conforming to [RFC
+        4122](https://tools.ietf.org/html/rfc4122), that is restricted by a
+        regular expression for interoperability reasons. A UUID is always 36
+        characters long, 32 hexadecimal symbols and 4 dashes (‘-‘).
+      example: b51ec534-ee48-4575-b6a9-ead2955b8069
     Currency:
       title: Currency
-      description: The currency codes defined in [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) as three-letter alphabetic codes are used as the standard naming representation for currencies.
+      description: >-
+        The currency codes defined in [ISO
+        4217](https://www.iso.org/iso-4217-currency-codes.html) as three-letter
+        alphabetic codes are used as the standard naming representation for
+        currencies.
       type: string
       minLength: 3
       maxLength: 3
@@ -2239,6 +2525,8 @@ components:
         - XDR
         - XOF
         - XPF
+        - XTS
+        - XXX
         - YER
         - ZAR
         - ZMW
@@ -2246,503 +2534,55 @@ components:
     Date:
       title: Date
       type: string
-      pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
-      description:
-        The API data type Date is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
-        This format, as specified in ISO 8601, contains a date only. A more readable version of the format is yyyy-MM-dd. Examples are "1982-05-23", "1987-08-05”.
+      pattern: >-
+        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
+      description: >-
+        The API data type Date is a JSON String in a lexical format that is
+        restricted by a regular expression for interoperability reasons. This
+        format, as specified in ISO 8601, contains a date only. A more readable
+        version of the format is yyyy-MM-dd. Examples are "1982-05-23",
+        "1987-08-05”.
     DateOfBirth:
       title: DateofBirth (type Date)
       type: string
-      pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
+      pattern: >-
+        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
       description: Date of Birth of the Party.
+      example: "1966-06-16"
     DateTime:
       title: DateTime
       type: string
-      pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$
-      description:
-        The API data type DateTime is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
-        The format is according to [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html), expressed in a combined date, time and time zone format. A more readable version of the format is yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]. Examples are "2016-05-24T08:38:08.699-04:00", "2016-05-24T08:38:08.699Z" (where Z indicates Zulu time zone, same as UTC).
+      pattern: >-
+        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$
+      description: >-
+        The API data type DateTime is a JSON String in a lexical format that is
+        restricted by a regular expression for interoperability reasons. The
+        format is according to [ISO
+        8601](https://www.iso.org/iso-8601-date-and-time-format.html), expressed
+        in a combined date, time and time zone format. A more readable version
+        of the format is yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]. Examples are
+        "2016-05-24T08:38:08.699-04:00", "2016-05-24T08:38:08.699Z" (where Z
+        indicates Zulu time zone, same as UTC).
+      example: "2016-05-24T08:38:08.699-04:00"
     ErrorCode:
       title: ErrorCode
       type: string
       pattern: ^[1-9]\d{3}$
-      description: The API data type ErrorCode is a JSON String of four characters, consisting of digits only. Negative numbers are not allowed. A leading zero is not allowed. Each error code in the API is a four-digit number, for example, 1234, where the first number (1 in the example) represents the high-level error category, the second number (2 in the example) represents the low-level error category, and the last two numbers (34 in the example) represent the specific error.
+      description: >-
+        The API data type ErrorCode is a JSON String of four characters,
+        consisting of digits only. Negative numbers are not allowed. A leading
+        zero is not allowed. Each error code in the API is a four-digit number,
+        for example, 1234, where the first number (1 in the example) represents
+        the high-level error category, the second number (2 in the example)
+        represents the low-level error category, and the last two numbers (34 in
+        the example) represent the specific error.
+      example: "5100"
     ErrorDescription:
       title: ErrorDescription
       type: string
       minLength: 1
       maxLength: 128
       description: Error description string.
-    ExtensionKey:
-      title: ExtensionKey
-      type: string
-      minLength: 1
-      maxLength: 32
-      description: Extension key.
-    ExtensionValue:
-      title: ExtensionValue
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Extension value.
-    FirstName:
-      title: FirstName
-      type: string
-      minLength: 1
-      maxLength: 128
-      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
-      description: First name of the Party (Name Type).
-    FspId:
-      title: FspId
-      type: string
-      minLength: 1
-      maxLength: 32
-      description: FSP identifier.
-    IlpCondition:
-      title: IlpCondition
-      type: string
-      pattern: ^[A-Za-z0-9-_]{43}$
-      maxLength: 48
-      description: Condition that must be attached to the transfer by the Payer.
-    IlpFulfilment:
-      title: IlpFulfilment
-      type: string
-      pattern: ^[A-Za-z0-9-_]{43}$
-      maxLength: 48
-      description: Fulfilment that must be attached to the transfer by the Payee.
-    IlpPacket:
-      title: IlpPacket
-      type: string
-      pattern: ^[A-Za-z0-9-_]+[=]{0,2}$
-      minLength: 1
-      maxLength: 32768
-      description: Information for recipient (transport layer information).
-    Integer:
-      title: Integer
-      type: string
-      pattern: ^[1-9]\d*$
-      description: The API data type Integer is a JSON String consisting of digits only. Negative numbers and leading zeroes are not allowed. The data type is always limited to a specific number of digits.
-    LastName:
-      title: LastName
-      type: string
-      minLength: 1
-      maxLength: 128
-      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
-      description: Last name of the Party (Name Type).
-    Latitude:
-      title: Latitude
-      type: string
-      pattern: ^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,6})?))$
-      description: The API data type Latitude is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
-    Longitude:
-      title: Longitude
-      type: string
-      pattern: ^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,6})?))$
-      description: The API data type Longitude is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
-    MerchantClassificationCode:
-      title: MerchantClassificationCode
-      type: string
-      pattern: ^[\d]{1,4}$
-      description: A limited set of pre-defined numbers. This list would be a limited set of numbers identifying a set of popular merchant types like School Fees, Pubs and Restaurants, Groceries, etc.
-    MiddleName:
-      title: MiddleName
-      type: string
-      minLength: 1
-      maxLength: 128
-      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
-      description: Middle name of the Party (Name Type).
-    Name:
-      title: Name
-      type: string
-      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
-      description:
-        The API data type Name is a JSON String, restricted by a regular expression to avoid characters which are generally not used in a name.
-
-
-        Regular Expression - The regular expression for restricting the Name type is "^(?!\s*$)[\w .,'-]{1,128}$". The restriction does not allow a string consisting of whitespace only, all Unicode characters are allowed, as well as the period (.) (apostrophe (‘), dash (-), comma (,) and space characters ( ).
-
-
-        **Note:** In some programming languages, Unicode support must be specifically enabled. For example, if Java is used, the flag UNICODE_CHARACTER_CLASS must be enabled to allow Unicode characters.
-    Note:
-      title: Note
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Memo assigned to transaction.
-    OtpValue:
-      title: OtpValue
-      type: string
-      pattern: ^\d{3,10}$
-      description: The API data type OtpValue is a JSON String of 3 to 10 characters, consisting of digits only. Negative numbers are not allowed. One or more leading zeros are allowed.
-    PartyIdentifier:
-      title: PartyIdentifier
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Identifier of the Party.
-    PartyIdType:
-      title: PartyIdType
-      type: string
-      enum:
-        - MSISDN
-        - EMAIL
-        - PERSONAL_ID
-        - BUSINESS
-        - DEVICE
-        - ACCOUNT_ID
-        - IBAN
-        - ALIAS
-      description: Below are the allowed values for the enumeration.
-
-        - MSISDN - An MSISDN (Mobile Station International Subscriber Directory Number, that is, the phone number) is used as reference to a participant. The MSISDN identifier should be in international format according to the [ITU-T E.164 standard](https://www.itu.int/rec/T-REC-E.164/en). Optionally, the MSISDN may be prefixed by a single plus sign, indicating the international prefix.
-
-        - EMAIL - An email is used as reference to a participant. The format of the email should be according to the informational [RFC 3696](https://tools.ietf.org/html/rfc3696).
-
-        - PERSONAL_ID - A personal identifier is used as reference to a participant. Examples of personal identification are passport number, birth certificate number, and national registration number. The identifier number is added in the PartyIdentifier element. The personal identifier type is added in the PartySubIdOrType element.
-
-        - BUSINESS - A specific Business (for example, an organization or a company) is used as reference to a participant. The BUSINESS identifier can be in any format. To make a transaction connected to a specific username or bill number in a Business, the PartySubIdOrType element should be used.
-
-        - DEVICE - A specific device (for example, a POS or ATM) ID connected to a specific business or organization is used as reference to a Party. For referencing a specific device under a specific business or organization, use the PartySubIdOrType element.
-
-        - ACCOUNT_ID - A bank account number or FSP account ID should be used as reference to a participant. The ACCOUNT_ID identifier can be in any format, as formats can greatly differ depending on country and FSP.
-
-        - IBAN - A bank account number or FSP account ID is used as reference to a participant. The IBAN identifier can consist of up to 34 alphanumeric characters and should be entered without whitespace.
-
-        - ALIAS An alias is used as reference to a participant. The alias should be created in the FSP as an alternative reference to an account owner. Another example of an alias is a username in the FSP system. The ALIAS identifier can be in any format. It is also possible to use the PartySubIdOrType element for identifying an account under an Alias defined by the PartyIdentifier.
-    PartyName:
-      title: PartyName
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Name of the Party. Could be a real name or a nickname.
-    PartySubIdOrType:
-      title: PartySubIdOrType
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Either a sub-identifier of a PartyIdentifier, or a sub-type of the PartyIdType, normally a PersonalIdentifierType.
-    PersonalIdentifierType:
-      title: PersonalIdentifierType
-      type: string
-      enum:
-        - PASSPORT
-        - NATIONAL_REGISTRATION
-        - DRIVING_LICENSE
-        - ALIEN_REGISTRATION
-        - NATIONAL_ID_CARD
-        - EMPLOYER_ID
-        - TAX_ID_NUMBER
-        - SENIOR_CITIZENS_CARD
-        - MARRIAGE_CERTIFICATE
-        - HEALTH_CARD
-        - VOTERS_ID
-        - UNITED_NATIONS
-        - OTHER_ID
-      description: Below are the allowed values for the enumeration.
-
-        - PASSPORT - A passport number is used as reference to a Party.
-
-        - NATIONAL_REGISTRATION - A national registration number is used as reference to a Party.
-
-        - DRIVING_LICENSE - A driving license is used as reference to a Party.
-
-        - ALIEN_REGISTRATION - An alien registration number is used as reference to a Party.
-
-        - NATIONAL_ID_CARD - A national ID card number is used as reference to a Party.
-
-        - EMPLOYER_ID - A tax identification number is used as reference to a Party.
-
-        - TAX_ID_NUMBER - A tax identification number is used as reference to a Party.
-
-        - SENIOR_CITIZENS_CARD - A senior citizens card number is used as reference to a Party.
-
-        - MARRIAGE_CERTIFICATE - A marriage certificate number is used as reference to a Party.
-
-        - HEALTH_CARD - A health card number is used as reference to a Party.
-
-        - VOTERS_ID - A voter’s identification number is used as reference to a Party.
-
-        - UNITED_NATIONS - An UN (United Nations) number is used as reference to a Party.
-
-        - OTHER_ID - Any other type of identification type number is used as reference to a Party.
-    QRCODE:
-      title: QRCODE
-      type: string
-      minLength: 1
-      maxLength: 64
-      description: QR code used as a One Time Password.
-    RefundReason:
-      title: RefundReason
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Reason for the refund.
-    TokenCode:
-      title: TokenCode
-      type: string
-      pattern: ^[0-9a-zA-Z]{4,32}$
-      description: The API data type TokenCode is a JSON String between 4 and 32 characters, consisting of digits or upper- or lowercase characters from a to z.
-    TransactionInitiator:
-      title: TransactionInitiator
-      type: string
-      enum:
-        - PAYER
-        - PAYEE
-      description: Below are the allowed values for the enumeration.
-
-        - PAYER - Sender of funds is initiating the transaction. The account to send from is either owned by the Payer or is connected to the Payer in some way.
-
-        - PAYEE - Recipient of the funds is initiating the transaction by sending a transaction request. The Payer must approve the transaction, either automatically by a pre-generated OTP or by pre-approval of the Payee, or by manually approving in his or her own Device.
-    TransactionInitiatorType:
-      title: TransactionInitiatorType
-      type: string
-      enum:
-        - CONSUMER
-        - AGENT
-        - BUSINESS
-        - DEVICE
-      description: Below are the allowed values for the enumeration.
-
-        - CONSUMER - Consumer is the initiator of the transaction.
-
-        - AGENT - Agent is the initiator of the transaction.
-
-        - BUSINESS - Business is the initiator of the transaction.
-
-        - DEVICE - Device is the initiator of the transaction.
-    TransactionRequestState:
-      title: TransactionRequestState
-      type: string
-      enum:
-        - RECEIVED
-        - PENDING
-        - ACCEPTED
-        - REJECTED
-      description: Below are the allowed values for the enumeration.
-
-        - RECEIVED - Payer FSP has received the transaction from the Payee FSP.
-
-        - PENDING - Payer FSP has sent the transaction request to the Payer.
-
-        - ACCEPTED - Payer has approved the transaction.
-
-        - REJECTED - Payer has rejected the transaction.
-    TransactionScenario:
-      title: TransactionScenario
-      type: string
-      enum:
-        - DEPOSIT
-        - WITHDRAWAL
-        - TRANSFER
-        - PAYMENT
-        - REFUND
-      description: Below are the allowed values for the enumeration.
-
-        - DEPOSIT - Used for performing a Cash-In (deposit) transaction. In a normal scenario, electronic funds are transferred from a Business account to a Consumer account, and physical cash is given from the Consumer to the Business User.
-
-        - WITHDRAWAL - Used for performing a Cash-Out (withdrawal) transaction. In a normal scenario, electronic funds are transferred from a Consumer’s account to a Business account, and physical cash is given from the Business User to the Consumer.
-
-        - TRANSFER - Used for performing a P2P (Peer to Peer, or Consumer to Consumer) transaction.
-
-        - PAYMENT - Usually used for performing a transaction from a Consumer to a Merchant or Organization, but could also be for a B2B (Business to Business) payment. The transaction could be online for a purchase in an Internet store, in a physical store where both the Consumer and Business User are present, a bill payment, a donation, and so on.
-
-        - REFUND - Used for performing a refund of transaction.
-    TransactionState:
-      title: TransactionState
-      type: string
-      enum:
-        - RECEIVED
-        - PENDING
-        - COMPLETED
-        - REJECTED
-      description: Below are the allowed values for the enumeration.
-
-        - RECEIVED - Payee FSP has received the transaction from the Payer FSP.
-
-        - PENDING - Payee FSP has validated the transaction.
-
-        - COMPLETED - Payee FSP has successfully performed the transaction.
-
-        - REJECTED - Payee FSP has failed to perform the transaction.
-    TransactionSubScenario:
-      title: TransactionSubScenario
-      type: string
-      pattern: ^[A-Z_]{1,32}$
-      description: Possible sub-scenario, defined locally within the scheme (UndefinedEnum Type).
-    TransferState:
-      title: TransferState
-      type: string
-      enum:
-        - RECEIVED
-        - RESERVED
-        - COMMITTED
-        - ABORTED
-      description: Below are the allowed values for the enumeration.
-
-        - RECEIVED - Next ledger has received the transfer.
-
-        - RESERVED - Next ledger has reserved the transfer.
-
-        - COMMITTED - Next ledger has successfully performed the transfer.
-
-        - ABORTED - Next ledger has aborted the transfer due to a rejection or failure to perform the transfer.
-    UndefinedEnum:
-      title: UndefinedEnum
-      type: string
-      pattern: ^[A-Z_]{1,32}$
-      description: The API data type UndefinedEnum is a JSON String consisting of 1 to 32 uppercase characters including an underscore character (_).
-
-    #Complex Types
-    AuthenticationInfo:
-      title: AuthenticationInfo
-      type: object
-      description: Data model for the complex type AuthenticationInfo.
-      properties:
-        authentication:
-          $ref: "#/components/schemas/AuthenticationType"
-          description: Type of authentication.
-          example: OTP
-        authenticationValue:
-          $ref: "#/components/schemas/AuthenticationValue"
-          description: Authentication value.
-          example: 1234
-      required:
-        - authentication
-        - authenticationValue
-    AuthorizationsIDPutResponse:
-      title: AuthorizationsIDPutResponse
-      type: object
-      description: The object sent in the PUT /authorizations/{ID} callback.
-      properties:
-        authenticationInfo:
-          $ref: "#/components/schemas/AuthenticationInfo"
-          description: OTP or QR Code if entered, otherwise empty.
-          example: OTP
-        responseType:
-          $ref: "#/components/schemas/AuthorizationResponse"
-          description: Enum containing response information; if the customer entered the authentication value, rejected the transaction, or requested a resend of the authentication value.
-          example: ENTERED
-      required:
-        - responseType
-    BulkQuotesIDPutResponse:
-      title: BulkQuotesIDPutResponse
-      type: object
-      description: The object sent in the PUT /bulkQuotes/{ID} callback.
-      properties:
-        individualQuoteResults:
-          type: array
-          maxItems: 1000
-          items:
-            $ref: "#/components/schemas/IndividualQuoteResult"
-          description: Fees for each individual transaction, if any of them are charged per transaction.
-        expiration:
-          $ref: "#/components/schemas/DateTime"
-          description: Date and time until when the quotation is valid and can be honored when used in the subsequent transaction request.
-          example: "2016-05-24T08:38:08.699-04:00"
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - expiration
-    BulkQuotesPostRequest:
-      title: BulkQuotesPostRequest
-      type: object
-      description: The object sent in the POST /bulkQuotes request.
-      properties:
-        bulkQuoteId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Common ID between the FSPs for the bulk quote object, decided by the Payer FSP. The ID should be reused for resends of the same bulk quote. A new ID should be generated for each new bulk quote.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
-        payer:
-          $ref: "#/components/schemas/Party"
-          description: Information about the Payer in the proposed financial transaction.
-        geoCode:
-          $ref: "#/components/schemas/GeoCode"
-          description: Longitude and Latitude of the initiating Party. Can be used to detect fraud.
-        expiration:
-          $ref: "#/components/schemas/DateTime"
-          description: Expiration is optional to let the Payee FSP know when a quote no longer needs to be returned.
-          example: "2016-05-24T08:38:08.699-04:00"
-        individualQuotes:
-          type: array
-          minItems: 1
-          maxItems: 1000
-          items:
-            $ref: "#/components/schemas/IndividualQuote"
-          description: List of quotes elements.
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - bulkQuoteId
-        - payer
-        - individualQuotes
-    BulkTransfersIDPutResponse:
-      title: BulkTransfersIDPutResponse
-      type: object
-      description: The object sent in the PUT /bulkTransfers/{ID} callback.
-      properties:
-        completedTimestamp:
-          $ref: "#/components/schemas/DateTime"
-          description: Time and date when the bulk transaction was completed.
-          example: "2016-05-24T08:38:08.699-04:00"
-        individualTransferResults:
-          type: array
-          maxItems: 1000
-          items:
-            $ref: "#/components/schemas/IndividualTransferResult"
-          description: List of IndividualTransferResult elements.
-        bulkTransferState:
-          $ref: "#/components/schemas/BulkTransferState"
-          description: The state of the bulk transfer.
-          example: RECEIVED
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - bulkTransferState
-    BulkTransfersPostRequest:
-      title: BulkTransfersPostRequest
-      type: object
-      description: The object sent in the POST /bulkTransfers request.
-      properties:
-        bulkTransferId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Common ID between the FSPs and the optional Switch for the bulk transfer object, decided by the Payer FSP. The ID should be reused for resends of the same bulk transfer. A new ID should be generated for each new bulk transfer.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
-        bulkQuoteId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: ID of the related bulk quote.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
-        payerFsp:
-          $ref: "#/components/schemas/FspId"
-          description: Payer FSP identifier.
-          example: 5678
-        payeeFsp:
-          $ref: "#/components/schemas/FspId"
-          description: Payee FSP identifier.
-          example: 1234
-        individualTransfers:
-          type: array
-          minItems: 1
-          maxItems: 1000
-          items:
-            $ref: "#/components/schemas/IndividualTransfer"
-          description: List of IndividualTransfer elements.
-        expiration:
-          $ref: "#/components/schemas/DateTime"
-          description: Expiration time of the transfers.
-          example: "2016-05-24T08:38:08.699-04:00"
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - bulkTransferId
-        - bulkQuoteId
-        - payerFsp
-        - payeeFsp
-        - individualTransfers
-        - expiration
     ErrorInformation:
       title: ErrorInformation
       type: object
@@ -2750,12 +2590,8 @@ components:
       properties:
         errorCode:
           $ref: "#/components/schemas/ErrorCode"
-          description: Specific error number.
-          example: 5100
         errorDescription:
           $ref: "#/components/schemas/ErrorDescription"
-          description: Error description string.
-          example: This is an error description.
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
       required:
@@ -2773,7 +2609,9 @@ components:
     ErrorInformationResponse:
       title: ErrorInformationResponse
       type: object
-      description: Data model for the complex type object that contains an optional element ErrorInformation used along with 4xx and 5xx responses.
+      description: >-
+        Data model for the complex type object that contains an optional element
+        ErrorInformation used along with 4xx and 5xx responses.
       properties:
         errorInformation:
           $ref: "#/components/schemas/ErrorInformation"
@@ -2784,17 +2622,23 @@ components:
       properties:
         key:
           $ref: "#/components/schemas/ExtensionKey"
-          description: Extension key.
         value:
           $ref: "#/components/schemas/ExtensionValue"
-          description: Extension value.
       required:
         - key
         - value
+    ExtensionKey:
+      title: ExtensionKey
+      type: string
+      minLength: 1
+      maxLength: 32
+      description: Extension key.
     ExtensionList:
       title: ExtensionList
       type: object
-      description: Data model for the complex type ExtensionList. An optional list of extensions, specific to deployment.
+      description: >-
+        Data model for the complex type ExtensionList. An optional list of
+        extensions, specific to deployment.
       properties:
         extension:
           type: array
@@ -2805,22 +2649,64 @@ components:
           description: Number of Extension elements.
       required:
         - extension
+    ExtensionValue:
+      title: ExtensionValue
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Extension value.
+    FirstName:
+      title: FirstName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: >-
+        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
+        .,''-]{1,128}$
+      description: First name of the Party (Name Type).
+      example: Henrik
+    FspId:
+      title: FspId
+      type: string
+      minLength: 1
+      maxLength: 32
+      description: FSP identifier.
     GeoCode:
       title: GeoCode
       type: object
-      description: Data model for the complex type GeoCode. Indicates the geographic location from where the transaction was initiated.
+      description: >-
+        Data model for the complex type GeoCode. Indicates the geographic
+        location from where the transaction was initiated.
       properties:
         latitude:
           $ref: "#/components/schemas/Latitude"
-          description: Latitude of the Party.
-          example: "+45.4215"
         longitude:
           $ref: "#/components/schemas/Longitude"
-          description: Longitude of the Party.
-          example: "+75.6972"
       required:
         - latitude
         - longitude
+    IlpCondition:
+      title: IlpCondition
+      type: string
+      pattern: ^[A-Za-z0-9-_]{43}$
+      maxLength: 48
+      description: Condition that must be attached to the transfer by the Payer.
+    IlpFulfilment:
+      title: IlpFulfilment
+      type: string
+      pattern: ^[A-Za-z0-9-_]{43}$
+      maxLength: 48
+      description: Fulfilment that must be attached to the transfer by the Payee.
+      example: WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8
+    IlpPacket:
+      title: IlpPacket
+      type: string
+      pattern: ^[A-Za-z0-9-_]+[=]{0,2}$
+      minLength: 1
+      maxLength: 32768
+      description: Information for recipient (transport layer information).
+      example: >-
+        AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
     IndividualQuote:
       title: IndividualQuote
       type: object
@@ -2828,39 +2714,22 @@ components:
       properties:
         quoteId:
           $ref: "#/components/schemas/CorrelationId"
-          description: Identifies the quote message.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
         transactionId:
           $ref: "#/components/schemas/CorrelationId"
-          description: Identifies the transaction message.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
         payee:
           $ref: "#/components/schemas/Party"
-          description: Information about the Payee in the proposed financial transaction.
         amountType:
           $ref: "#/components/schemas/AmountType"
-          description: SEND for sendAmount, RECEIVE for receiveAmount.
-          example: RECEIVE
         amount:
           $ref: "#/components/schemas/Money"
-          description: Depending on amountType
-            If SEND - The amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees. The amount is updated by each participating entity in the transaction.
-            If RECEIVE - The amount the Payee should receive, that is, the amount that should be sent to the receiver exclusive of any fees. The amount is not updated by any of the participating entities.
         fees:
           $ref: "#/components/schemas/Money"
-          description: The fees in the transaction.
-            The fees element should be empty if fees should be non-disclosed.
-            The fees element should be non-empty if fees should be disclosed.
         transactionType:
           $ref: "#/components/schemas/TransactionType"
-          description: Type of transaction that the quote is requested for.
         note:
           $ref: "#/components/schemas/Note"
-          description: Memo that will be attached to the transaction.
-          example: Note sent to Payee.
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
       required:
         - quoteId
         - transactionId
@@ -2875,37 +2744,24 @@ components:
       properties:
         quoteId:
           $ref: "#/components/schemas/CorrelationId"
-          description: Identifies the quote message.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
         payee:
           $ref: "#/components/schemas/Party"
-          description: Information about the Payee in the proposed financial transaction.
         transferAmount:
           $ref: "#/components/schemas/Money"
-          description: The amount of money that the Payee FSP should receive.
         payeeReceiveAmount:
           $ref: "#/components/schemas/Money"
-          description: The amount of Money that the Payee should receive in the end-to-end transaction. Optional as the Payee FSP might not want to disclose any optional Payee fees.
         payeeFspFee:
           $ref: "#/components/schemas/Money"
-          description: Payee FSP’s part of the transaction fee.
         payeeFspCommission:
           $ref: "#/components/schemas/Money"
-          description: Transaction commission from the Payee FSP.
         ilpPacket:
           $ref: "#/components/schemas/IlpPacket"
-          description: The ILP Packet that must be attached to the transfer by the Payer.
-          example: AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
         condition:
           $ref: "#/components/schemas/IlpCondition"
-          description: The condition that must be attached to the transfer by the Payer.
-          example: f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA
         errorInformation:
           $ref: "#/components/schemas/ErrorInformation"
-          description: Error code, category description. **Note:** receiveAmount, payeeFspFee, payeeFspCommission, expiration, ilpPacket, condition should not be set if errorInformation is set.
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
       required:
         - quoteId
     IndividualTransfer:
@@ -2915,22 +2771,14 @@ components:
       properties:
         transferId:
           $ref: "#/components/schemas/CorrelationId"
-          description: Identifies messages related to the same /transfers sequence.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
         transferAmount:
           $ref: "#/components/schemas/Money"
-          description: Transaction amount to be sent.
         ilpPacket:
           $ref: "#/components/schemas/IlpPacket"
-          description: ILP Packet containing the amount delivered to the Payee and the ILP Address of the Payee and any other end-to-end data.
-          example: AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
         condition:
           $ref: "#/components/schemas/IlpCondition"
-          description: Condition that must be fulfilled to commit the transfer.
-          example: f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
       required:
         - transferId
         - transferAmount
@@ -2943,20 +2791,68 @@ components:
       properties:
         transferId:
           $ref: "#/components/schemas/CorrelationId"
-          description: Identifies messages related to the same /transfers sequence.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
         fulfilment:
           $ref: "#/components/schemas/IlpFulfilment"
-          description: Fulfilment of the condition specified with the transaction. **Note:** Either fulfilment or errorInformation should be set, not both.
-          example: WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8
         errorInformation:
           $ref: "#/components/schemas/ErrorInformation"
-          description: If transfer is REJECTED, error information may be provided. **Note:** Either fulfilment or errorInformation should be set, not both.
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
       required:
         - transferId
+    Integer:
+      title: Integer
+      type: string
+      pattern: ^[1-9]\d*$
+      description: >-
+        The API data type Integer is a JSON String consisting of digits only.
+        Negative numbers and leading zeroes are not allowed. The data type is
+        always limited to a specific number of digits.
+    LastName:
+      title: LastName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: >-
+        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
+        .,''-]{1,128}$
+      description: Last name of the Party (Name Type).
+      example: Karlsson
+    Latitude:
+      title: Latitude
+      type: string
+      pattern: >-
+        ^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,6})?))$
+      description: >-
+        The API data type Latitude is a JSON String in a lexical format that is
+        restricted by a regular expression for interoperability reasons.
+      example: "+45.4215"
+    Longitude:
+      title: Longitude
+      type: string
+      pattern: >-
+        ^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,6})?))$
+      description: >-
+        The API data type Longitude is a JSON String in a lexical format that is
+        restricted by a regular expression for interoperability reasons.
+      example: "+75.6972"
+    MerchantClassificationCode:
+      title: MerchantClassificationCode
+      type: string
+      pattern: ^[\d]{1,4}$
+      description: >-
+        A limited set of pre-defined numbers. This list would be a limited set
+        of numbers identifying a set of popular merchant types like School Fees,
+        Pubs and Restaurants, Groceries, etc.
+    MiddleName:
+      title: MiddleName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: >-
+        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
+        .,''-]{1,128}$
+      description: Middle name of the Party (Name Type).
+      example: Johannes
     Money:
       title: Money
       type: object
@@ -2964,15 +2860,45 @@ components:
       properties:
         currency:
           $ref: "#/components/schemas/Currency"
-          description: Currency of the amount.
-          example: USD
         amount:
           $ref: "#/components/schemas/Amount"
-          description: Amount of Money.
-          example: "123.45"
       required:
         - currency
         - amount
+    Name:
+      title: Name
+      type: string
+      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
+      description: >-
+        The API data type Name is a JSON String, restricted by a regular
+        expression to avoid characters which are generally not used in a name.
+
+
+        Regular Expression - The regular expression for restricting the Name
+        type is "^(?!\s*$)[\w .,'-]{1,128}$". The restriction does not allow a
+        string consisting of whitespace only, all Unicode characters are
+        allowed, as well as the period (.) (apostrophe (‘), dash (-), comma (,)
+        and space characters ( ).
+
+
+        **Note:** In some programming languages, Unicode support must be
+        specifically enabled. For example, if Java is used, the flag
+        UNICODE_CHARACTER_CLASS must be enabled to allow Unicode characters.
+    Note:
+      title: Note
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Memo assigned to transaction.
+      example: Note sent to Payee.
+    OtpValue:
+      title: OtpValue
+      type: string
+      pattern: ^\d{3,10}$
+      description: >-
+        The API data type OtpValue is a JSON String of 3 to 10 characters,
+        consisting of digits only. Negative numbers are not allowed. One or more
+        leading zeros are allowed.
     ParticipantsIDPutResponse:
       title: ParticipantsIDPutResponse
       type: object
@@ -2984,11 +2910,11 @@ components:
             $ref: "#/components/schemas/PartyResult"
           minItems: 1
           maxItems: 10000
-          description: List of PartyResult elements that were either created or failed to be created.
+          description: >-
+            List of PartyResult elements that were either created or failed to
+            be created.
         currency:
           $ref: "#/components/schemas/Currency"
-          description: Indicate that the provided Currency was set to be supported by each successfully added PartyIdInfo.
-          example: USD
       required:
         - partyList
     ParticipantsPostRequest:
@@ -2998,47 +2924,43 @@ components:
       properties:
         requestId:
           $ref: "#/components/schemas/CorrelationId"
-          description: The ID of the request, decided by the client. Used for identification of the callback from the server.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
         partyList:
           type: array
           items:
             $ref: "#/components/schemas/PartyIdInfo"
           minItems: 1
           maxItems: 10000
-          description: List of PartyIdInfo elements that the client would like to update or create FSP information about.
+          description: >-
+            List of PartyIdInfo elements that the client would like to update or
+            create FSP information about.
         currency:
           $ref: "#/components/schemas/Currency"
-          description: Indicate that the provided Currency is supported by each PartyIdInfo in the list.
-          example: USD
       required:
         - requestId
         - partyList
     ParticipantsTypeIDPutResponse:
       title: ParticipantsTypeIDPutResponse
       type: object
-      description: The object sent in the PUT /participants/{Type}/{ID}/{SubId} and /participants/{Type}/{ID} callbacks.
+      description: >-
+        The object sent in the PUT /participants/{Type}/{ID}/{SubId} and
+        /participants/{Type}/{ID} callbacks.
       properties:
         fspId:
           $ref: "#/components/schemas/FspId"
-          description: FSP Identifier that the Party belongs to.
-          example: 1234
     ParticipantsTypeIDSubIDPostRequest:
       title: ParticipantsTypeIDSubIDPostRequest
       type: object
-      description: The object sent in the POST /participants/{Type}/{ID}/{SubId} and /participants/{Type}/{ID} requests. An additional optional ExtensionList element has been added as part of v1.1 changes.
+      description: >-
+        The object sent in the POST /participants/{Type}/{ID}/{SubId} and
+        /participants/{Type}/{ID} requests. An additional optional ExtensionList
+        element has been added as part of v1.1 changes.
       properties:
         fspId:
           $ref: "#/components/schemas/FspId"
-          description: FSP Identifier that the Party belongs to.
-          example: 1234
         currency:
           $ref: "#/components/schemas/Currency"
-          description: Indicate that the provided Currency is supported by the Party.
-          example: USD
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
       required:
         - fspId
     PartiesTypeIDPutResponse:
@@ -3048,7 +2970,6 @@ components:
       properties:
         party:
           $ref: "#/components/schemas/Party"
-          description: Information regarding the requested Party.
       required:
         - party
     Party:
@@ -3058,18 +2979,12 @@ components:
       properties:
         partyIdInfo:
           $ref: "#/components/schemas/PartyIdInfo"
-          description: Party Id type, id, sub ID or type, and FSP Id.
         merchantClassificationCode:
           $ref: "#/components/schemas/MerchantClassificationCode"
-          description: Used in the context of Payee Information, where the Payee happens to be a merchant accepting merchant payments.
-          example: 4321
         name:
           $ref: "#/components/schemas/PartyName"
-          description: Display name of the Party, could be a real name or a nick name.
-          example: Henrik Karlsson
         personalInfo:
           $ref: "#/components/schemas/PartyPersonalInfo"
-          description: Personal information used to verify identity of Party such as first, middle, last name and date of birth.
       required:
         - partyIdInfo
     PartyComplexName:
@@ -3079,43 +2994,101 @@ components:
       properties:
         firstName:
           $ref: "#/components/schemas/FirstName"
-          description: Party’s first name.
-          example: Henrik
         middleName:
           $ref: "#/components/schemas/MiddleName"
-          description: Party’s middle name.
-          example: Johannes
         lastName:
           $ref: "#/components/schemas/LastName"
-          description: Party’s last name.
-          example: Karlsson
     PartyIdInfo:
       title: PartyIdInfo
       type: object
-      description: Data model for the complex type PartyIdInfo. An ExtensionList element has been added to this reqeust in version v1.1
+      description: >-
+        Data model for the complex type PartyIdInfo. An ExtensionList element
+        has been added to this reqeust in version v1.1
       properties:
         partyIdType:
           $ref: "#/components/schemas/PartyIdType"
-          description: Type of the identifier.
-          example: PERSONAL_ID
         partyIdentifier:
           $ref: "#/components/schemas/PartyIdentifier"
-          description: An identifier for the Party.
-          example: 16135551212
         partySubIdOrType:
           $ref: "#/components/schemas/PartySubIdOrType"
-          description: A sub-identifier or sub-type for the Party.
-          example: DRIVING_LICENSE
         fspId:
           $ref: "#/components/schemas/FspId"
-          description: FSP ID (if known).
-          example: 1234
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
       required:
         - partyIdType
         - partyIdentifier
+    PartyIdType:
+      title: PartyIdType
+      type: string
+      enum:
+        - MSISDN
+        - EMAIL
+        - PERSONAL_ID
+        - BUSINESS
+        - DEVICE
+        - ACCOUNT_ID
+        - IBAN
+        - ALIAS
+      description: >-
+        Below are the allowed values for the enumeration.
+
+        - MSISDN - An MSISDN (Mobile Station International Subscriber Directory
+        Number, that is, the phone number) is used as reference to a
+        participant. The MSISDN identifier should be in international format
+        according to the [ITU-T E.164
+        standard](https://www.itu.int/rec/T-REC-E.164/en). Optionally, the
+        MSISDN may be prefixed by a single plus sign, indicating the
+        international prefix.
+
+        - EMAIL - An email is used as reference to a participant. The format of
+        the email should be according to the informational [RFC
+        3696](https://tools.ietf.org/html/rfc3696).
+
+        - PERSONAL_ID - A personal identifier is used as reference to a
+        participant. Examples of personal identification are passport number,
+        birth certificate number, and national registration number. The
+        identifier number is added in the PartyIdentifier element. The personal
+        identifier type is added in the PartySubIdOrType element.
+
+        - BUSINESS - A specific Business (for example, an organization or a
+        company) is used as reference to a participant. The BUSINESS identifier
+        can be in any format. To make a transaction connected to a specific
+        username or bill number in a Business, the PartySubIdOrType element
+        should be used.
+
+        - DEVICE - A specific device (for example, a POS or ATM) ID connected to
+        a specific business or organization is used as reference to a Party. For
+        referencing a specific device under a specific business or organization,
+        use the PartySubIdOrType element.
+
+        - ACCOUNT_ID - A bank account number or FSP account ID should be used as
+        reference to a participant. The ACCOUNT_ID identifier can be in any
+        format, as formats can greatly differ depending on country and FSP.
+
+        - IBAN - A bank account number or FSP account ID is used as reference to
+        a participant. The IBAN identifier can consist of up to 34 alphanumeric
+        characters and should be entered without whitespace.
+
+        - ALIAS An alias is used as reference to a participant. The alias should
+        be created in the FSP as an alternative reference to an account owner.
+        Another example of an alias is a username in the FSP system. The ALIAS
+        identifier can be in any format. It is also possible to use the
+        PartySubIdOrType element for identifying an account under an Alias
+        defined by the PartyIdentifier.
+    PartyIdentifier:
+      title: PartyIdentifier
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Identifier of the Party.
+      example: "16135551212"
+    PartyName:
+      title: PartyName
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Name of the Party. Could be a real name or a nickname.
     PartyPersonalInfo:
       title: PartyPersonalInfo
       type: object
@@ -3123,11 +3096,8 @@ components:
       properties:
         complexName:
           $ref: "#/components/schemas/PartyComplexName"
-          description: First, middle and last name for the Party.
         dateOfBirth:
           $ref: "#/components/schemas/DateOfBirth"
-          description: Date of birth for the Party.
-          example: "1966-06-16"
     PartyResult:
       title: PartyResult
       type: object
@@ -3135,12 +3105,79 @@ components:
       properties:
         partyId:
           $ref: "#/components/schemas/PartyIdInfo"
-          description: Party Id type, id, sub ID or type, and FSP Id.
         errorInformation:
           $ref: "#/components/schemas/ErrorInformation"
-          description: If the Party failed to be added, error information should be provided. Otherwise, this parameter should be empty to indicate success.
       required:
         - partyId
+    PartySubIdOrType:
+      title: PartySubIdOrType
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: >-
+        Either a sub-identifier of a PartyIdentifier, or a sub-type of the
+        PartyIdType, normally a PersonalIdentifierType.
+    PersonalIdentifierType:
+      title: PersonalIdentifierType
+      type: string
+      enum:
+        - PASSPORT
+        - NATIONAL_REGISTRATION
+        - DRIVING_LICENSE
+        - ALIEN_REGISTRATION
+        - NATIONAL_ID_CARD
+        - EMPLOYER_ID
+        - TAX_ID_NUMBER
+        - SENIOR_CITIZENS_CARD
+        - MARRIAGE_CERTIFICATE
+        - HEALTH_CARD
+        - VOTERS_ID
+        - UNITED_NATIONS
+        - OTHER_ID
+      description: >-
+        Below are the allowed values for the enumeration.
+
+        - PASSPORT - A passport number is used as reference to a Party.
+
+        - NATIONAL_REGISTRATION - A national registration number is used as
+        reference to a Party.
+
+        - DRIVING_LICENSE - A driving license is used as reference to a Party.
+
+        - ALIEN_REGISTRATION - An alien registration number is used as reference
+        to a Party.
+
+        - NATIONAL_ID_CARD - A national ID card number is used as reference to a
+        Party.
+
+        - EMPLOYER_ID - A tax identification number is used as reference to a
+        Party.
+
+        - TAX_ID_NUMBER - A tax identification number is used as reference to a
+        Party.
+
+        - SENIOR_CITIZENS_CARD - A senior citizens card number is used as
+        reference to a Party.
+
+        - MARRIAGE_CERTIFICATE - A marriage certificate number is used as
+        reference to a Party.
+
+        - HEALTH_CARD - A health card number is used as reference to a Party.
+
+        - VOTERS_ID - A voter’s identification number is used as reference to a
+        Party.
+
+        - UNITED_NATIONS - An UN (United Nations) number is used as reference to
+        a Party.
+
+        - OTHER_ID - Any other type of identification type number is used as
+        reference to a Party.
+    QRCODE:
+      title: QRCODE
+      type: string
+      minLength: 1
+      maxLength: 64
+      description: QR code used as a One Time Password.
     QuotesIDPutResponse:
       title: QuotesIDPutResponse
       type: object
@@ -3148,34 +3185,22 @@ components:
       properties:
         transferAmount:
           $ref: "#/components/schemas/Money"
-          description: The amount of money that the Payee FSP should receive.
         payeeReceiveAmount:
           $ref: "#/components/schemas/Money"
-          description: The amount of Money that the Payee should receive in the end-to-end transaction. Optional as the Payee FSP might not want to disclose any optional Payee fees.
         payeeFspFee:
           $ref: "#/components/schemas/Money"
-          description: Payee FSP’s part of the transaction fee.
         payeeFspCommission:
           $ref: "#/components/schemas/Money"
-          description: Transaction commission from the Payee FSP.
         expiration:
           $ref: "#/components/schemas/DateTime"
-          description: Date and time until when the quotation is valid and can be honored when used in the subsequent transaction.
-          example: "2016-05-24T08:38:08.699-04:00"
         geoCode:
           $ref: "#/components/schemas/GeoCode"
-          description: Longitude and Latitude of the Payee. Can be used to detect fraud.
         ilpPacket:
           $ref: "#/components/schemas/IlpPacket"
-          description: The ILP Packet that must be attached to the transfer by the Payer.
-          example: “AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA”
         condition:
           $ref: "#/components/schemas/IlpCondition"
-          description: The condition that must be attached to the transfer by the Payer.
-          example: f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
       required:
         - transferAmount
         - expiration
@@ -3188,53 +3213,30 @@ components:
       properties:
         quoteId:
           $ref: "#/components/schemas/CorrelationId"
-          description: Common ID between the FSPs for the quote object, decided by the Payer FSP. The ID should be reused for resends of the same quote for a transaction. A new ID should be generated for each new quote for a transaction.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
         transactionId:
           $ref: "#/components/schemas/CorrelationId"
-          description: Common ID (decided by the Payer FSP) between the FSPs for the future transaction object. The actual transaction will be created as part of a successful transfer process. The ID should be reused for resends of the same quote for a transaction. A new ID should be generated for each new quote for a transaction.
-          example: a8323bc6-c228-4df2-ae82-e5a997baf899
         transactionRequestId:
           $ref: "#/components/schemas/CorrelationId"
-          description: Identifies an optional previously-sent transaction request.
-          example: a8323bc6-c228-4df2-ae82-e5a997baf890
         payee:
           $ref: "#/components/schemas/Party"
-          description: Information about the Payee in the proposed financial transaction.
         payer:
           $ref: "#/components/schemas/Party"
-          description: Information about the Payer in the proposed financial transaction.
         amountType:
           $ref: "#/components/schemas/AmountType"
-          description: SEND for send amount, RECEIVE for receive amount.
-          example: SEND
         amount:
           $ref: "#/components/schemas/Money"
-          description: Depending on amountType -
-            If SEND - The amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees. The amount is updated by each participating entity in the transaction.
-            If RECEIVE - The amount the Payee should receive, that is, the amount that should be sent to the receiver exclusive any fees. The amount is not updated by any of the participating entities.
         fees:
           $ref: "#/components/schemas/Money"
-          description: The fees in the transaction.
-            The fees element should be empty if fees should be non-disclosed.
-            The fees element should be non-empty if fees should be disclosed.
         transactionType:
           $ref: "#/components/schemas/TransactionType"
-          description: Type of transaction for which the quote is requested.
         geoCode:
           $ref: "#/components/schemas/GeoCode"
-          description: Longitude and Latitude of the initiating Party. Can be used to detect fraud.
         note:
           $ref: "#/components/schemas/Note"
-          description: A memo that will be attached to the transaction.
-          example: Free-text memo.
         expiration:
           $ref: "#/components/schemas/DateTime"
-          description: Expiration is optional. It can be set to get a quick failure in case the peer FSP takes too long to respond. Also, it may be beneficial for Consumer, Agent, and Merchant to know that their request has a time limit.
-          example: "2016-05-24T08:38:08.699-04:00"
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
       required:
         - quoteId
         - transactionId
@@ -3250,43 +3252,50 @@ components:
       properties:
         originalTransactionId:
           $ref: "#/components/schemas/CorrelationId"
-          description: Reference to the original transaction ID that is requested to be refunded.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
         refundReason:
           $ref: "#/components/schemas/RefundReason"
-          description: Free text indicating the reason for the refund.
-          example: Free text indicating reason for the refund.
       required:
         - originalTransactionId
+    RefundReason:
+      title: RefundReason
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Reason for the refund.
+      example: Free text indicating reason for the refund.
+    TokenCode:
+      title: TokenCode
+      type: string
+      pattern: ^[0-9a-zA-Z]{4,32}$
+      description: >-
+        The API data type TokenCode is a JSON String between 4 and 32
+        characters, consisting of digits or upper- or lowercase characters from
+        a to z.
     Transaction:
       title: Transaction
       type: object
-      description: Data model for the complex type Transaction. The Transaction type is used to carry end-to-end data between the Payer FSP and the Payee FSP in the ILP Packet. Both the transactionId and the quoteId in the data model are decided by the Payer FSP in the POST /quotes request.
+      description: >-
+        Data model for the complex type Transaction. The Transaction type is
+        used to carry end-to-end data between the Payer FSP and the Payee FSP in
+        the ILP Packet. Both the transactionId and the quoteId in the data model
+        are decided by the Payer FSP in the POST /quotes request.
       properties:
         transactionId:
           $ref: "#/components/schemas/CorrelationId"
-          description: ID of the transaction, the ID is decided by the Payer FSP during the creation of the quote.
         quoteId:
           $ref: "#/components/schemas/CorrelationId"
-          description: ID of the quote, the ID is decided by the Payer FSP during the creation of the quote.
         payee:
           $ref: "#/components/schemas/Party"
-          description: Information about the Payee in the proposed financial transaction.
         payer:
           $ref: "#/components/schemas/Party"
-          description: Information about the Payer in the proposed financial transaction.
         amount:
           $ref: "#/components/schemas/Money"
-          description: Transaction amount to be sent.
         transactionType:
           $ref: "#/components/schemas/TransactionType"
-          description: Type of the transaction.
         note:
           $ref: "#/components/schemas/Note"
-          description: Memo associated to the transaction, intended to the Payee.
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
       required:
         - transactionId
         - quoteId
@@ -3294,6 +3303,54 @@ components:
         - payer
         - amount
         - transactionType
+    TransactionInitiator:
+      title: TransactionInitiator
+      type: string
+      enum:
+        - PAYER
+        - PAYEE
+      description: >-
+        Below are the allowed values for the enumeration.
+
+        - PAYER - Sender of funds is initiating the transaction. The account to
+        send from is either owned by the Payer or is connected to the Payer in
+        some way.
+
+        - PAYEE - Recipient of the funds is initiating the transaction by
+        sending a transaction request. The Payer must approve the transaction,
+        either automatically by a pre-generated OTP or by pre-approval of the
+        Payee, or by manually approving in his or her own Device.
+      example: PAYEE
+    TransactionInitiatorType:
+      title: TransactionInitiatorType
+      type: string
+      enum:
+        - CONSUMER
+        - AGENT
+        - BUSINESS
+        - DEVICE
+      description: |-
+        Below are the allowed values for the enumeration.
+        - CONSUMER - Consumer is the initiator of the transaction.
+        - AGENT - Agent is the initiator of the transaction.
+        - BUSINESS - Business is the initiator of the transaction.
+        - DEVICE - Device is the initiator of the transaction.
+      example: CONSUMER
+    TransactionRequestState:
+      title: TransactionRequestState
+      type: string
+      enum:
+        - RECEIVED
+        - PENDING
+        - ACCEPTED
+        - REJECTED
+      description: |-
+        Below are the allowed values for the enumeration.
+        - RECEIVED - Payer FSP has received the transaction from the Payee FSP.
+        - PENDING - Payer FSP has sent the transaction request to the Payer.
+        - ACCEPTED - Payer has approved the transaction.
+        - REJECTED - Payer has rejected the transaction.
+      example: RECEIVED
     TransactionRequestsIDPutResponse:
       title: TransactionRequestsIDPutResponse
       type: object
@@ -3301,15 +3358,10 @@ components:
       properties:
         transactionId:
           $ref: "#/components/schemas/CorrelationId"
-          description: Identifies a related transaction (if a transaction has been created).
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
         transactionRequestState:
           $ref: "#/components/schemas/TransactionRequestState"
-          description: State of the transaction request.
-          example: RECEIVED
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
       required:
         - transactionRequestState
     TransactionRequestsPostRequest:
@@ -3319,66 +3371,86 @@ components:
       properties:
         transactionRequestId:
           $ref: "#/components/schemas/CorrelationId"
-          description: Common ID between the FSPs for the transaction request object, decided by the Payee FSP. The ID should be reused for resends of the same transaction request. A new ID should be generated for each new transaction request.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
         payee:
           $ref: "#/components/schemas/Party"
-          description: Information about the Payee in the proposed financial transaction.
         payer:
           $ref: "#/components/schemas/PartyIdInfo"
-          description: Information about the Payer type, id, sub-type/id, FSP Id in the proposed financial transaction.
         amount:
           $ref: "#/components/schemas/Money"
-          description: Requested amount to be transferred from the Payer to Payee.
         transactionType:
           $ref: "#/components/schemas/TransactionType"
-          description: Type of transaction.
         note:
           $ref: "#/components/schemas/Note"
-          description: Reason for the transaction request, intended to the Payer.
-          example: Free-text memo.
         geoCode:
           $ref: "#/components/schemas/GeoCode"
-          description: Longitude and Latitude of the initiating Party. Can be used to detect fraud.
         authenticationType:
           $ref: "#/components/schemas/AuthenticationType"
-          description: OTP or QR Code, otherwise empty.
-          example: OTP
         expiration:
           $ref: "#/components/schemas/DateTime"
-          description: Can be set to get a quick failure in case the peer FSP takes too long to respond. Also, it may be beneficial for Consumer, Agent, Merchant to know that their request has a time limit.
-          example: "2016-05-24T08:38:08.699-04:00"
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
       required:
         - transactionRequestId
         - payee
         - payer
         - amount
         - transactionType
-    TransactionsIDPutResponse:
-      title: TransactionsIDPutResponse
-      type: object
-      description: The object sent in the PUT /transactions/{ID} callback.
-      properties:
-        completedTimestamp:
-          $ref: "#/components/schemas/DateTime"
-          description: Time and date when the transaction was completed.
-          example: "2016-05-24T08:38:08.699-04:00"
-        transactionState:
-          $ref: "#/components/schemas/TransactionState"
-          description: State of the transaction.
-          example: RECEIVED
-        code:
-          $ref: "#/components/schemas/Code"
-          description: Optional redemption information provided to Payer after transaction has been completed.
-          example: Test-Code
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - transactionState
+    TransactionScenario:
+      title: TransactionScenario
+      type: string
+      enum:
+        - DEPOSIT
+        - WITHDRAWAL
+        - TRANSFER
+        - PAYMENT
+        - REFUND
+      description: >-
+        Below are the allowed values for the enumeration.
+
+        - DEPOSIT - Used for performing a Cash-In (deposit) transaction. In a
+        normal scenario, electronic funds are transferred from a Business
+        account to a Consumer account, and physical cash is given from the
+        Consumer to the Business User.
+
+        - WITHDRAWAL - Used for performing a Cash-Out (withdrawal) transaction.
+        In a normal scenario, electronic funds are transferred from a Consumer’s
+        account to a Business account, and physical cash is given from the
+        Business User to the Consumer.
+
+        - TRANSFER - Used for performing a P2P (Peer to Peer, or Consumer to
+        Consumer) transaction.
+
+        - PAYMENT - Usually used for performing a transaction from a Consumer to
+        a Merchant or Organization, but could also be for a B2B (Business to
+        Business) payment. The transaction could be online for a purchase in an
+        Internet store, in a physical store where both the Consumer and Business
+        User are present, a bill payment, a donation, and so on.
+
+        - REFUND - Used for performing a refund of transaction.
+      example: DEPOSIT
+    TransactionState:
+      title: TransactionState
+      type: string
+      enum:
+        - RECEIVED
+        - PENDING
+        - COMPLETED
+        - REJECTED
+      description: |-
+        Below are the allowed values for the enumeration.
+        - RECEIVED - Payee FSP has received the transaction from the Payer FSP.
+        - PENDING - Payee FSP has validated the transaction.
+        - COMPLETED - Payee FSP has successfully performed the transaction.
+        - REJECTED - Payee FSP has failed to perform the transaction.
+      example: RECEIVED
+    TransactionSubScenario:
+      title: TransactionSubScenario
+      type: string
+      pattern: ^[A-Z_]{1,32}$
+      description: >-
+        Possible sub-scenario, defined locally within the scheme (UndefinedEnum
+        Type).
+      example: LOCALLY_DEFINED_SUBSCENARIO
     TransactionType:
       title: TransactionType
       type: object
@@ -3386,31 +3458,55 @@ components:
       properties:
         scenario:
           $ref: "#/components/schemas/TransactionScenario"
-          description: Deposit, withdrawal, refund, …
-          example: DEPOSIT
         subScenario:
           $ref: "#/components/schemas/TransactionSubScenario"
-          description: Possible sub-scenario, defined locally within the scheme.
-          example: Locally defined sub-scenario.
         initiator:
           $ref: "#/components/schemas/TransactionInitiator"
-          description: Who is initiating the transaction - Payer or Payee.
-          example: PAYEE
         initiatorType:
           $ref: "#/components/schemas/TransactionInitiatorType"
-          description: Consumer, agent, business, …
-          example: CONSUMER
         refundInfo:
           $ref: "#/components/schemas/Refund"
-          description: Extra information specific to a refund scenario. Should only be populated if scenario is REFUND.
         balanceOfPayments:
           $ref: "#/components/schemas/BalanceOfPayments"
-          description: Balance of Payments code.
-          example: 123
       required:
         - scenario
         - initiator
         - initiatorType
+    TransactionsIDPutResponse:
+      title: TransactionsIDPutResponse
+      type: object
+      description: The object sent in the PUT /transactions/{ID} callback.
+      properties:
+        completedTimestamp:
+          $ref: "#/components/schemas/DateTime"
+        transactionState:
+          $ref: "#/components/schemas/TransactionState"
+        code:
+          $ref: "#/components/schemas/Code"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - transactionState
+    TransferState:
+      title: TransferState
+      type: string
+      enum:
+        - RECEIVED
+        - RESERVED
+        - COMMITTED
+        - ABORTED
+      description: >-
+        Below are the allowed values for the enumeration.
+
+        - RECEIVED - Next ledger has received the transfer.
+
+        - RESERVED - Next ledger has reserved the transfer.
+
+        - COMMITTED - Next ledger has successfully performed the transfer.
+
+        - ABORTED - Next ledger has aborted the transfer due to a rejection or
+        failure to perform the transfer.
+      example: RESERVED
     TransfersIDPatchResponse:
       title: TransfersIDPatchResponse
       type: object
@@ -3418,15 +3514,10 @@ components:
       properties:
         completedTimestamp:
           $ref: "#/components/schemas/DateTime"
-          description: Time and date when the transaction was completed.
-          example: "2020-05-19T08:38:08.699-04:00"
         transferState:
           $ref: "#/components/schemas/TransferState"
-          description: State of the transfer.
-          example: RESERVED
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
       required:
         - completedTimestamp
         - transferState
@@ -3437,19 +3528,12 @@ components:
       properties:
         fulfilment:
           $ref: "#/components/schemas/IlpFulfilment"
-          description: Fulfilment of the condition specified with the transaction. Mandatory if transfer has completed successfully.
-          example: WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8
         completedTimestamp:
           $ref: "#/components/schemas/DateTime"
-          description: Time and date when the transaction was completed.
-          example: "2016-05-24T08:38:08.699-04:00"
         transferState:
           $ref: "#/components/schemas/TransferState"
-          description: State of the transfer.
-          example: COMMITTED
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
       required:
         - transferState
     TransfersPostRequest:
@@ -3459,34 +3543,20 @@ components:
       properties:
         transferId:
           $ref: "#/components/schemas/CorrelationId"
-          description: The common ID between the FSPs and the optional Switch for the transfer object, decided by the Payer FSP. The ID should be reused for resends of the same transfer. A new ID should be generated for each new transfer.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
         payeeFsp:
           $ref: "#/components/schemas/FspId"
-          description: Payee FSP in the proposed financial transaction.
-          example: 1234
         payerFsp:
           $ref: "#/components/schemas/FspId"
-          description: Payer FSP in the proposed financial transaction.
-          example: 5678
         amount:
           $ref: "#/components/schemas/Money"
-          description: The transfer amount to be sent.
         ilpPacket:
           $ref: "#/components/schemas/IlpPacket"
-          description: The ILP Packet containing the amount delivered to the Payee and the ILP Address of the Payee and any other end-to-end data.
-          example: AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
         condition:
           $ref: "#/components/schemas/IlpCondition"
-          description: The condition that must be fulfilled to commit the transfer.
-          example: f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA
         expiration:
           $ref: "#/components/schemas/DateTime"
-          description: Expiration can be set to get a quick failure expiration of the transfer. The transfer should be rolled back if no fulfilment is delivered before this time.
-          example: "2016-05-24T08:38:08.699-04:00"
         extensionList:
           $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
       required:
         - transferId
         - payeeFsp
@@ -3495,7 +3565,189 @@ components:
         - ilpPacket
         - condition
         - expiration
+    U2FPIN:
+      title: U2FPIN
+      type: string
+      pattern: ^\S{1,64}$
+      minLength: 1
+      maxLength: 64
+      description: >
+        U2F challenge-response, where payer FSP verifies if the response
+        provided by end-user device matches the previously registered key.
+    U2FPinValue:
+      title: U2FPinValue
+      type: object
+      description: >
+        U2F challenge-response, where payer FSP verifies if the response
+        provided by end-user device matches the previously registered key.
+      properties:
+        pinValue:
+          allOf:
+            - $ref: "#/components/schemas/U2FPIN"
+          description: U2F challenge-response.
+        counter:
+          allOf:
+            - $ref: "#/components/schemas/Integer"
+          description: >-
+            Sequential counter used for cloning detection. Present only for U2F
+            authentication.
+      required:
+        - pinValue
+        - counter
+    UndefinedEnum:
+      title: UndefinedEnum
+      type: string
+      pattern: ^[A-Z_]{1,32}$
+      description: >-
+        The API data type UndefinedEnum is a JSON String consisting of 1 to 32
+        uppercase characters including an underscore character (_).
+  parameters:
+    Accept:
+      name: Accept
+      in: header
+      required: true
+      schema:
+        type: string
+      description: >-
+        The `Accept` header field indicates the version of the API the client
+        would like the server to use.
+    Content-Length:
+      name: Content-Length
+      in: header
+      required: false
+      schema:
+        type: integer
+      description: >-
+        The `Content-Length` header field indicates the anticipated size of the
+        payload body. Only sent if there is a body.
 
+
+        **Note:** The API supports a maximum size of 5242880 bytes (5
+        Megabytes).
+    Content-Type:
+      name: Content-Type
+      in: header
+      schema:
+        type: string
+      required: true
+      description: >-
+        The `Content-Type` header indicates the specific version of the API used
+        to send the payload body.
+    Date:
+      name: Date
+      in: header
+      schema:
+        type: string
+      required: true
+      description: The `Date` header field indicates the date when the request was sent.
+    FSPIOP-Destination:
+      name: FSPIOP-Destination
+      in: header
+      schema:
+        type: string
+      required: false
+      description: >-
+        The `FSPIOP-Destination` header field is a non-HTTP standard field used
+        by the API for HTTP header based routing of requests and responses to
+        the destination. The field must be set by the original sender of the
+        request if the destination is known (valid for all services except GET
+        /parties) so that any entities between the client and the server do not
+        need to parse the payload for routing purposes. If the destination is
+        not known (valid for service GET /parties), the field should be left
+        empty.
+    FSPIOP-Encryption:
+      name: FSPIOP-Encryption
+      in: header
+      schema:
+        type: string
+      required: false
+      description: >-
+        The `FSPIOP-Encryption` header field is a non-HTTP standard field used
+        by the API for applying end-to-end encryption of the request.
+    FSPIOP-HTTP-Method:
+      name: FSPIOP-HTTP-Method
+      in: header
+      schema:
+        type: string
+      required: false
+      description: >-
+        The `FSPIOP-HTTP-Method` header field is a non-HTTP standard field used
+        by the API for signature verification, should contain the service HTTP
+        method. Required if signature verification is used, for more
+        information, see [the API Signature
+        document](https://github.com/mojaloop/docs/tree/main/Specification%20Document%20Set).
+    FSPIOP-Signature:
+      name: FSPIOP-Signature
+      in: header
+      schema:
+        type: string
+      required: false
+      description: >-
+        The `FSPIOP-Signature` header field is a non-HTTP standard field used by
+        the API for applying an end-to-end request signature.
+    FSPIOP-Source:
+      name: FSPIOP-Source
+      in: header
+      schema:
+        type: string
+      required: true
+      description: >-
+        The `FSPIOP-Source` header field is a non-HTTP standard field used by
+        the API for identifying the sender of the HTTP request. The field should
+        be set by the original sender of the request. Required for routing and
+        signature verification (see header field `FSPIOP-Signature`).
+    FSPIOP-URI:
+      name: FSPIOP-URI
+      in: header
+      schema:
+        type: string
+      required: false
+      description: >-
+        The `FSPIOP-URI` header field is a non-HTTP standard field used by the
+        API for signature verification, should contain the service URI. Required
+        if signature verification is used, for more information, see [the API
+        Signature
+        document](https://github.com/mojaloop/docs/tree/main/Specification%20Document%20Set).
+    ID:
+      name: ID
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The identifier value.
+    SubId:
+      name: SubId
+      in: path
+      required: true
+      schema:
+        type: string
+      description: >-
+        A sub-identifier of the party identifier, or a sub-type of the party
+        identifier's type. For example, `PASSPORT`, `DRIVING_LICENSE`.
+    Type:
+      name: Type
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The type of the party identifier. For example, `MSISDN`, `PERSONAL_ID`.
+    X-Forwarded-For:
+      name: X-Forwarded-For
+      in: header
+      schema:
+        type: string
+      required: false
+      description: >-
+        The `X-Forwarded-For` header field is an unofficially accepted standard
+        used for informational purposes of the originating client IP address, as
+        a request might pass multiple proxies, firewalls, and so on. Multiple
+        `X-Forwarded-For` values should be expected and supported by
+        implementers of the API.
+
+
+        **Note:** An alternative to `X-Forwarded-For` is defined in [RFC
+        7239](https://tools.ietf.org/html/rfc7239). However, to this point RFC
+        7239 is less-used and supported than `X-Forwarded-For`.
   responses:
     "200":
       description: OK
@@ -3509,11 +3761,9 @@ components:
             $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          description: Content-Length header
-          $ref: "#/components/parameters/Content-Length"
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          description: Content-Length header
-          $ref: "#/components/parameters/Content-Type"
+          $ref: "#/components/headers/Content-Type"
     "401":
       description: Unauthorized
       content:
@@ -3522,9 +3772,9 @@ components:
             $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: "#/components/parameters/Content-Length"
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: "#/components/parameters/Content-Type"
+          $ref: "#/components/headers/Content-Type"
     "403":
       description: Forbidden
       content:
@@ -3533,9 +3783,9 @@ components:
             $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: "#/components/parameters/Content-Length"
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: "#/components/parameters/Content-Type"
+          $ref: "#/components/headers/Content-Type"
     "404":
       description: Not Found
       content:
@@ -3544,9 +3794,9 @@ components:
             $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: "#/components/parameters/Content-Length"
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: "#/components/parameters/Content-Type"
+          $ref: "#/components/headers/Content-Type"
     "405":
       description: Method Not Allowed
       content:
@@ -3555,9 +3805,9 @@ components:
             $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: "#/components/parameters/Content-Length"
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: "#/components/parameters/Content-Type"
+          $ref: "#/components/headers/Content-Type"
     "406":
       description: Not Acceptable
       content:
@@ -3566,9 +3816,9 @@ components:
             $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: "#/components/parameters/Content-Length"
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: "#/components/parameters/Content-Type"
+          $ref: "#/components/headers/Content-Type"
     "501":
       description: Not Implemented
       content:
@@ -3577,9 +3827,9 @@ components:
             $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: "#/components/parameters/Content-Length"
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: "#/components/parameters/Content-Type"
+          $ref: "#/components/headers/Content-Type"
     "503":
       description: Service Unavailable
       content:
@@ -3588,116 +3838,25 @@ components:
             $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: "#/components/parameters/Content-Length"
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: "#/components/parameters/Content-Type"
-
-  parameters:
-    #Header parameters
-    Accept:
-      name: Accept
-      in: header
-      required: true
-      schema:
-        type: string
-      description: The `Accept` header field indicates the version of the API the client would like the server to use.
+          $ref: "#/components/headers/Content-Type"
+  headers:
     Content-Length:
-      name: Content-Length
-      in: header
       required: false
       schema:
         type: integer
-      description:
-        The `Content-Length` header field indicates the anticipated size of the payload body. Only sent if there is a body.
+      description: >-
+        The `Content-Length` header field indicates the anticipated size of the
+        payload body. Only sent if there is a body.
 
 
-        **Note:** The API supports a maximum size of 5242880 bytes (5 Megabytes).
+        **Note:** The API supports a maximum size of 5242880 bytes (5
+        Megabytes).
     Content-Type:
-      name: Content-Type
-      in: header
       schema:
         type: string
       required: true
-      description: The `Content-Type` header indicates the specific version of the API used to send the payload body.
-    Date:
-      name: Date
-      in: header
-      schema:
-        type: string
-      required: true
-      description: The `Date` header field indicates the date when the request was sent.
-    X-Forwarded-For:
-      name: X-Forwarded-For
-      in: header
-      schema:
-        type: string
-      required: false
-      description:
-        The `X-Forwarded-For` header field is an unofficially accepted standard used for informational purposes of the originating client IP address, as a request might pass multiple proxies, firewalls, and so on. Multiple `X-Forwarded-For` values should be expected and supported by implementers of the API.
-
-
-        **Note:** An alternative to `X-Forwarded-For` is defined in [RFC 7239](https://tools.ietf.org/html/rfc7239). However, to this point RFC 7239 is less-used and supported than `X-Forwarded-For`.
-    FSPIOP-Source:
-      name: FSPIOP-Source
-      in: header
-      schema:
-        type: string
-      required: true
-      description: The `FSPIOP-Source` header field is a non-HTTP standard field used by the API for identifying the sender of the HTTP request. The field should be set by the original sender of the request. Required for routing and signature verification (see header field `FSPIOP-Signature`).
-    FSPIOP-Destination:
-      name: FSPIOP-Destination
-      in: header
-      schema:
-        type: string
-      required: false
-      description: The `FSPIOP-Destination` header field is a non-HTTP standard field used by the API for HTTP header based routing of requests and responses to the destination. The field must be set by the original sender of the request if the destination is known (valid for all services except GET /parties) so that any entities between the client and the server do not need to parse the payload for routing purposes. If the destination is not known (valid for service GET /parties), the field should be left empty.
-    FSPIOP-Encryption:
-      name: FSPIOP-Encryption
-      in: header
-      schema:
-        type: string
-      required: false
-      description: The `FSPIOP-Encryption` header field is a non-HTTP standard field used by the API for applying end-to-end encryption of the request.
-    FSPIOP-Signature:
-      name: FSPIOP-Signature
-      in: header
-      schema:
-        type: string
-      required: false
-      description: The `FSPIOP-Signature` header field is a non-HTTP standard field used by the API for applying an end-to-end request signature.
-    FSPIOP-URI:
-      name: FSPIOP-URI
-      in: header
-      schema:
-        type: string
-      required: false
-      description: The `FSPIOP-URI` header field is a non-HTTP standard field used by the API for signature verification, should contain the service URI. Required if signature verification is used, for more information, see [the API Signature document](https://github.com/mojaloop/docs/tree/master/Specification%20Document%20Set).
-    FSPIOP-HTTP-Method:
-      name: FSPIOP-HTTP-Method
-      in: header
-      schema:
-        type: string
-      required: false
-      description: The `FSPIOP-HTTP-Method` header field is a non-HTTP standard field used by the API for signature verification, should contain the service HTTP method. Required if signature verification is used, for more information, see [the API Signature document](https://github.com/mojaloop/docs/tree/master/Specification%20Document%20Set).
-    #Path parameters
-    ID:
-      name: ID
-      in: path
-      required: true
-      schema:
-        type: string
-      description: The identifier value.
-    Type:
-      name: Type
-      in: path
-      required: true
-      schema:
-        type: string
-      description: The type of the party identifier. For example, `MSISDN`, `PERSONAL_ID`.
-    SubId:
-      name: SubId
-      in: path
-      required: true
-      schema:
-        type: string
-      description: A sub-identifier of the party identifier, or a sub-type of the party identifier's type. For example, `PASSPORT`, `DRIVING_LICENSE`.
+      description: >-
+        The `Content-Type` header indicates the specific version of the API used
+        to send the payload body.

--- a/fspiop-api/documents/v1.1-document-set/fspiop-v1.1-openapi3.yaml
+++ b/fspiop-api/documents/v1.1-document-set/fspiop-v1.1-openapi3.yaml
@@ -1,2082 +1,2473 @@
-openapi: "3.0.2"
+openapi: 3.0.2
 info:
-  version: "1.1"
+  version: '1.1'
   title: Open API for FSP Interoperability (FSPIOP)
-  description:
-    Based on [API Definition updated on 2020-05-19 Version 1.1](https://github.com/mojaloop/mojaloop-specification/blob/master/documents/v1.1-document-set/API%20Definition_v1.1.pdf).
+  description: >-
+    Based on [API Definition updated on 2020-05-19 Version
+    1.1](https://github.com/mojaloop/mojaloop-specification/blob/master/documents/v1.1-document-set/API%20Definition_v1.1.pdf).
 
 
-    **Note:** The API supports a maximum size of 65536 bytes (64 Kilobytes) in the HTTP header.
+    **Note:** The API supports a maximum size of 65536 bytes (64 Kilobytes) in
+    the HTTP header.
   license:
     name: CC BY-ND 4.0
     url: https://github.com/mojaloop/mojaloop-specification/blob/master/LICENSE.md
   contact:
-    name: "Sam Kummary"
+    name: Sam Kummary
     url: https://github.com/mojaloop/mojaloop-specification/issues
 servers:
-  - url: "{protocol}://hostname:<port>/switch/"
+  - url: protocol://hostname:<port>/switch/
     variables:
       protocol:
         enum:
           - http
           - https
         default: https
-
 paths:
-  #Participants
   /participants/{Type}/{ID}:
     parameters:
-      #Path
-      - $ref: "#/components/parameters/Type"
-      - $ref: "#/components/parameters/ID"
-      #Headers
-      - $ref: "#/components/parameters/Content-Type"
-      - $ref: "#/components/parameters/Date"
-      - $ref: "#/components/parameters/X-Forwarded-For"
-      - $ref: "#/components/parameters/FSPIOP-Source"
-      - $ref: "#/components/parameters/FSPIOP-Destination"
-      - $ref: "#/components/parameters/FSPIOP-Encryption"
-      - $ref: "#/components/parameters/FSPIOP-Signature"
-      - $ref: "#/components/parameters/FSPIOP-URI"
-      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+      - $ref: '#/components/parameters/Type'
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
     post:
-      description: The HTTP request `POST /participants/{Type}/{ID}` (or `POST /participants/{Type}/{ID}/{SubId}`) is used to create information in the server regarding the provided identity, defined by `{Type}`, `{ID}`, and optionally `{SubId}` (for example, `POST /participants/MSISDN/123456789` or `POST /participants/BUSINESS/shoecompany/employee1`). An ExtensionList element has been added to this reqeust in version v1.1
+      description: >-
+        The HTTP request `POST /participants/{Type}/{ID}` (or `POST
+        /participants/{Type}/{ID}/{SubId}`) is used to create information in the
+        server regarding the provided identity, defined by `{Type}`, `{ID}`, and
+        optionally `{SubId}` (for example, `POST /participants/MSISDN/123456789`
+        or `POST /participants/BUSINESS/shoecompany/employee1`). An
+        ExtensionList element has been added to this reqeust in version v1.1
       summary: Create participant information
       tags:
         - participants
       operationId: ParticipantsByIDAndType
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
-        - $ref: "#/components/parameters/Content-Length"
+        - $ref: '#/components/parameters/Accept'
+        - $ref: '#/components/parameters/Content-Length'
       requestBody:
         description: Participant information to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ParticipantsTypeIDSubIDPostRequest"
+              $ref: '#/components/schemas/ParticipantsTypeIDSubIDPostRequest'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     get:
-      description: The HTTP request `GET /participants/{Type}/{ID}` (or `GET /participants/{Type}/{ID}/{SubId}`) is used to find out in which FSP the requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}`, is located (for example, `GET /participants/MSISDN/123456789`, or `GET /participants/BUSINESS/shoecompany/employee1`). This HTTP request should support a query string for filtering of currency. To use filtering of currency, the HTTP request `GET /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is the requested currency.
+      description: >-
+        The HTTP request `GET /participants/{Type}/{ID}` (or `GET
+        /participants/{Type}/{ID}/{SubId}`) is used to find out in which FSP the
+        requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}`,
+        is located (for example, `GET /participants/MSISDN/123456789`, or `GET
+        /participants/BUSINESS/shoecompany/employee1`). This HTTP request should
+        support a query string for filtering of currency. To use filtering of
+        currency, the HTTP request `GET /participants/{Type}/{ID}?currency=XYZ`
+        should be used, where `XYZ` is the requested currency.
       summary: Look up participant information
       tags:
         - participants
       operationId: ParticipantsByTypeAndID
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
+        - $ref: '#/components/parameters/Accept'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     put:
-      description: The callback `PUT /participants/{Type}/{ID}` (or `PUT /participants/{Type}/{ID}/{SubId}`) is used to inform the client of a successful result of the lookup, creation, or deletion of the FSP information related to the Party. If the FSP information is deleted, the fspId element should be empty; otherwise the element should include the FSP information for the Party.
+      description: >-
+        The callback `PUT /participants/{Type}/{ID}` (or `PUT
+        /participants/{Type}/{ID}/{SubId}`) is used to inform the client of a
+        successful result of the lookup, creation, or deletion of the FSP
+        information related to the Party. If the FSP information is deleted, the
+        fspId element should be empty; otherwise the element should include the
+        FSP information for the Party.
       summary: Return participant information
       tags:
         - participants
       operationId: ParticipantsByTypeAndID3
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
+        - $ref: '#/components/parameters/Content-Length'
       requestBody:
         description: Participant information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ParticipantsTypeIDPutResponse"
+              $ref: '#/components/schemas/ParticipantsTypeIDPutResponse'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     delete:
-      description:
-        The HTTP request `DELETE /participants/{Type}/{ID}` (or `DELETE /participants/{Type}/{ID}/{SubId}`) is used to delete information in the server regarding the provided identity, defined by `{Type}` and `{ID}`) (for example, `DELETE /participants/MSISDN/123456789`), and optionally `{SubId}`. This HTTP request should support a query string to delete FSP information regarding a specific currency only. To delete a specific currency only, the HTTP request `DELETE /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is the requested currency.
+      description: >-
+        The HTTP request `DELETE /participants/{Type}/{ID}` (or `DELETE
+        /participants/{Type}/{ID}/{SubId}`) is used to delete information in the
+        server regarding the provided identity, defined by `{Type}` and `{ID}`)
+        (for example, `DELETE /participants/MSISDN/123456789`), and optionally
+        `{SubId}`. This HTTP request should support a query string to delete FSP
+        information regarding a specific currency only. To delete a specific
+        currency only, the HTTP request `DELETE
+        /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is
+        the requested currency.
 
 
-        **Note:** The Account Lookup System should verify that it is the Party’s current FSP that is deleting the FSP information.
+        **Note:** The Account Lookup System should verify that it is the Party’s
+        current FSP that is deleting the FSP information.
       summary: Delete participant information
       tags:
         - participants
       operationId: ParticipantsByTypeAndID2
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
+        - $ref: '#/components/parameters/Accept'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /participants/{Type}/{ID}/error:
     put:
-      description: If the server is unable to find, create or delete the associated FSP of the provided identity, or another processing error occurred, the error callback `PUT /participants/{Type}/{ID}/error` (or `PUT /participants/{Type}/{ID}/{SubId}/error`) is used.
+      description: >-
+        If the server is unable to find, create or delete the associated FSP of
+        the provided identity, or another processing error occurred, the error
+        callback `PUT /participants/{Type}/{ID}/error` (or `PUT
+        /participants/{Type}/{ID}/{SubId}/error`) is used.
       summary: Return participant information error
       tags:
         - participants
       operationId: ParticipantsErrorByTypeAndID
       parameters:
-        #Path
-        - $ref: "#/components/parameters/Type"
-        - $ref: "#/components/parameters/ID"
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/Type'
+        - $ref: '#/components/parameters/ID'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ErrorInformationObject"
+              $ref: '#/components/schemas/ErrorInformationObject'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /participants/{Type}/{ID}/{SubId}:
     parameters:
-      #Path
-      - $ref: "#/components/parameters/Type"
-      - $ref: "#/components/parameters/ID"
-      - $ref: "#/components/parameters/SubId"
-      #Headers
-      - $ref: "#/components/parameters/Content-Type"
-      - $ref: "#/components/parameters/Date"
-      - $ref: "#/components/parameters/X-Forwarded-For"
-      - $ref: "#/components/parameters/FSPIOP-Source"
-      - $ref: "#/components/parameters/FSPIOP-Destination"
-      - $ref: "#/components/parameters/FSPIOP-Encryption"
-      - $ref: "#/components/parameters/FSPIOP-Signature"
-      - $ref: "#/components/parameters/FSPIOP-URI"
-      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+      - $ref: '#/components/parameters/Type'
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/SubId'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
     post:
-      description: The HTTP request `POST /participants/{Type}/{ID}` (or `POST /participants/{Type}/{ID}/{SubId}`) is used to create information in the server regarding the provided identity, defined by `{Type}`, `{ID}`, and optionally `{SubId}` (for example, `POST /participants/MSISDN/123456789` or `POST /participants/BUSINESS/shoecompany/employee1`). An ExtensionList element has been added to this reqeust in version v1.1
+      description: >-
+        The HTTP request `POST /participants/{Type}/{ID}` (or `POST
+        /participants/{Type}/{ID}/{SubId}`) is used to create information in the
+        server regarding the provided identity, defined by `{Type}`, `{ID}`, and
+        optionally `{SubId}` (for example, `POST /participants/MSISDN/123456789`
+        or `POST /participants/BUSINESS/shoecompany/employee1`). An
+        ExtensionList element has been added to this reqeust in version v1.1
       summary: Create participant information
       tags:
         - participants
       operationId: ParticipantsSubIdByTypeAndIDPost
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
-        - $ref: "#/components/parameters/Content-Length"
+        - $ref: '#/components/parameters/Accept'
+        - $ref: '#/components/parameters/Content-Length'
       requestBody:
         description: Participant information to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ParticipantsTypeIDSubIDPostRequest"
+              $ref: '#/components/schemas/ParticipantsTypeIDSubIDPostRequest'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     get:
-      description: The HTTP request `GET /participants/{Type}/{ID}` (or `GET /participants/{Type}/{ID}/{SubId}`) is used to find out in which FSP the requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}`, is located (for example, `GET /participants/MSISDN/123456789`, or `GET /participants/BUSINESS/shoecompany/employee1`). This HTTP request should support a query string for filtering of currency. To use filtering of currency, the HTTP request `GET /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is the requested currency.
+      description: >-
+        The HTTP request `GET /participants/{Type}/{ID}` (or `GET
+        /participants/{Type}/{ID}/{SubId}`) is used to find out in which FSP the
+        requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}`,
+        is located (for example, `GET /participants/MSISDN/123456789`, or `GET
+        /participants/BUSINESS/shoecompany/employee1`). This HTTP request should
+        support a query string for filtering of currency. To use filtering of
+        currency, the HTTP request `GET /participants/{Type}/{ID}?currency=XYZ`
+        should be used, where `XYZ` is the requested currency.
       summary: Look up participant information
       tags:
         - participants
       operationId: ParticipantsSubIdByTypeAndID
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
+        - $ref: '#/components/parameters/Accept'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     put:
-      description: The callback `PUT /participants/{Type}/{ID}` (or `PUT /participants/{Type}/{ID}/{SubId}`) is used to inform the client of a successful result of the lookup, creation, or deletion of the FSP information related to the Party. If the FSP information is deleted, the fspId element should be empty; otherwise the element should include the FSP information for the Party.
+      description: >-
+        The callback `PUT /participants/{Type}/{ID}` (or `PUT
+        /participants/{Type}/{ID}/{SubId}`) is used to inform the client of a
+        successful result of the lookup, creation, or deletion of the FSP
+        information related to the Party. If the FSP information is deleted, the
+        fspId element should be empty; otherwise the element should include the
+        FSP information for the Party.
       summary: Return participant information
       tags:
         - participants
       operationId: ParticipantsSubIdByTypeAndID3
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
+        - $ref: '#/components/parameters/Content-Length'
       requestBody:
         description: Participant information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ParticipantsTypeIDPutResponse"
+              $ref: '#/components/schemas/ParticipantsTypeIDPutResponse'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     delete:
-      description:
-        The HTTP request `DELETE /participants/{Type}/{ID}` (or `DELETE /participants/{Type}/{ID}/{SubId}`) is used to delete information in the server regarding the provided identity, defined by `{Type}` and `{ID}`) (for example, `DELETE /participants/MSISDN/123456789`), and optionally `{SubId}`. This HTTP request should support a query string to delete FSP information regarding a specific currency only. To delete a specific currency only, the HTTP request `DELETE /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is the requested currency.
+      description: >-
+        The HTTP request `DELETE /participants/{Type}/{ID}` (or `DELETE
+        /participants/{Type}/{ID}/{SubId}`) is used to delete information in the
+        server regarding the provided identity, defined by `{Type}` and `{ID}`)
+        (for example, `DELETE /participants/MSISDN/123456789`), and optionally
+        `{SubId}`. This HTTP request should support a query string to delete FSP
+        information regarding a specific currency only. To delete a specific
+        currency only, the HTTP request `DELETE
+        /participants/{Type}/{ID}?currency=XYZ` should be used, where `XYZ` is
+        the requested currency.
 
 
-        **Note:** The Account Lookup System should verify that it is the Party’s current FSP that is deleting the FSP information.
+        **Note:** The Account Lookup System should verify that it is the Party’s
+        current FSP that is deleting the FSP information.
       summary: Delete participant information
       tags:
         - participants
       operationId: ParticipantsSubIdByTypeAndID2
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
+        - $ref: '#/components/parameters/Accept'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /participants/{Type}/{ID}/{SubId}/error:
     put:
-      description: If the server is unable to find, create or delete the associated FSP of the provided identity, or another processing error occurred, the error callback `PUT /participants/{Type}/{ID}/error` (or `PUT /participants/{Type}/{ID}/{SubId}/error`) is used.
+      description: >-
+        If the server is unable to find, create or delete the associated FSP of
+        the provided identity, or another processing error occurred, the error
+        callback `PUT /participants/{Type}/{ID}/error` (or `PUT
+        /participants/{Type}/{ID}/{SubId}/error`) is used.
       summary: Return participant information error
       tags:
         - participants
       operationId: ParticipantsSubIdErrorByTypeAndID
       parameters:
-        #Path
-        - $ref: "#/components/parameters/Type"
-        - $ref: "#/components/parameters/ID"
-        - $ref: "#/components/parameters/SubId"
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/Type'
+        - $ref: '#/components/parameters/ID'
+        - $ref: '#/components/parameters/SubId'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ErrorInformationObject"
+              $ref: '#/components/schemas/ErrorInformationObject'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /participants:
     post:
-      description: The HTTP request `POST /participants` is used to create information in the server regarding the provided list of identities. This request should be used for bulk creation of FSP information for more than one Party. The optional currency parameter should indicate that each provided Party supports the currency.
+      description: >-
+        The HTTP request `POST /participants` is used to create information in
+        the server regarding the provided list of identities. This request
+        should be used for bulk creation of FSP information for more than one
+        Party. The optional currency parameter should indicate that each
+        provided Party supports the currency.
       summary: Create bulk participant information
       tags:
         - participants
       operationId: Participants1
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/Accept'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Participant information to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ParticipantsPostRequest"
+              $ref: '#/components/schemas/ParticipantsPostRequest'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /participants/{ID}:
     put:
-      description: The callback `PUT /participants/{ID}` is used to inform the client of the result of the creation of the provided list of identities.
+      description: >-
+        The callback `PUT /participants/{ID}` is used to inform the client of
+        the result of the creation of the provided list of identities.
       summary: Return bulk participant information
       tags:
         - participants
       operationId: putParticipantsByID
       parameters:
-        #Path
-        - $ref: "#/components/parameters/ID"
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/ID'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Participant information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ParticipantsIDPutResponse"
+              $ref: '#/components/schemas/ParticipantsIDPutResponse'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /participants/{ID}/error:
     put:
-      description: If there is an error during FSP information creation in the server, the error callback `PUT /participants/{ID}/error` is used. The `{ID}` in the URI should contain the requestId that was used for the creation of the participant information.
+      description: >-
+        If there is an error during FSP information creation in the server, the
+        error callback `PUT /participants/{ID}/error` is used. The `{ID}` in the
+        URI should contain the requestId that was used for the creation of the
+        participant information.
       summary: Return bulk participant information error
       tags:
         - participants
       operationId: ParticipantsByIDAndError
       parameters:
-        #Path
-        - $ref: "#/components/parameters/ID"
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/ID'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ErrorInformationObject"
+              $ref: '#/components/schemas/ErrorInformationObject'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
-
-  #Parties
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /parties/{Type}/{ID}:
     parameters:
-      #Path
-      - $ref: "#/components/parameters/Type"
-      - $ref: "#/components/parameters/ID"
-      #Headers
-      - $ref: "#/components/parameters/Content-Type"
-      - $ref: "#/components/parameters/Date"
-      - $ref: "#/components/parameters/X-Forwarded-For"
-      - $ref: "#/components/parameters/FSPIOP-Source"
-      - $ref: "#/components/parameters/FSPIOP-Destination"
-      - $ref: "#/components/parameters/FSPIOP-Encryption"
-      - $ref: "#/components/parameters/FSPIOP-Signature"
-      - $ref: "#/components/parameters/FSPIOP-URI"
-      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+      - $ref: '#/components/parameters/Type'
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
     get:
-      description: The HTTP request `GET /parties/{Type}/{ID}` (or `GET /parties/{Type}/{ID}/{SubId}`) is used to look up information regarding the requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}` (for example, `GET /parties/MSISDN/123456789`, or `GET /parties/BUSINESS/shoecompany/employee1`).
+      description: >-
+        The HTTP request `GET /parties/{Type}/{ID}` (or `GET
+        /parties/{Type}/{ID}/{SubId}`) is used to look up information regarding
+        the requested Party, defined by `{Type}`, `{ID}` and optionally
+        `{SubId}` (for example, `GET /parties/MSISDN/123456789`, or `GET
+        /parties/BUSINESS/shoecompany/employee1`).
       summary: Look up party information
       tags:
         - parties
       operationId: PartiesByTypeAndID
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
+        - $ref: '#/components/parameters/Accept'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     put:
-      description: The callback `PUT /parties/{Type}/{ID}` (or `PUT /parties/{Type}/{ID}/{SubId}`) is used to inform the client of a successful result of the Party information lookup.
+      description: >-
+        The callback `PUT /parties/{Type}/{ID}` (or `PUT
+        /parties/{Type}/{ID}/{SubId}`) is used to inform the client of a
+        successful result of the Party information lookup.
       summary: Return party information
       tags:
         - parties
       operationId: PartiesByTypeAndID2
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
+        - $ref: '#/components/parameters/Content-Length'
       requestBody:
         description: Party information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PartiesTypeIDPutResponse"
+              $ref: '#/components/schemas/PartiesTypeIDPutResponse'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /parties/{Type}/{ID}/error:
     put:
-      description: If the server is unable to find Party information of the provided identity, or another processing error occurred, the error callback `PUT /parties/{Type}/{ID}/error` (or `PUT /parties/{Type}/{ID}/{SubI}/error`) is used.
+      description: >-
+        If the server is unable to find Party information of the provided
+        identity, or another processing error occurred, the error callback `PUT
+        /parties/{Type}/{ID}/error` (or `PUT /parties/{Type}/{ID}/{SubI}/error`)
+        is used.
       summary: Return party information error
       tags:
         - parties
       operationId: PartiesErrorByTypeAndID
       parameters:
-        #Path
-        - $ref: "#/components/parameters/Type"
-        - $ref: "#/components/parameters/ID"
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/Type'
+        - $ref: '#/components/parameters/ID'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ErrorInformationObject"
+              $ref: '#/components/schemas/ErrorInformationObject'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /parties/{Type}/{ID}/{SubId}:
     parameters:
-      #Path
-      - $ref: "#/components/parameters/Type"
-      - $ref: "#/components/parameters/ID"
-      - $ref: "#/components/parameters/SubId"
-      #Headers
-      - $ref: "#/components/parameters/Content-Type"
-      - $ref: "#/components/parameters/Date"
-      - $ref: "#/components/parameters/X-Forwarded-For"
-      - $ref: "#/components/parameters/FSPIOP-Source"
-      - $ref: "#/components/parameters/FSPIOP-Destination"
-      - $ref: "#/components/parameters/FSPIOP-Encryption"
-      - $ref: "#/components/parameters/FSPIOP-Signature"
-      - $ref: "#/components/parameters/FSPIOP-URI"
-      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+      - $ref: '#/components/parameters/Type'
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/SubId'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
     get:
-      description: The HTTP request `GET /parties/{Type}/{ID}` (or `GET /parties/{Type}/{ID}/{SubId}`) is used to look up information regarding the requested Party, defined by `{Type}`, `{ID}` and optionally `{SubId}` (for example, `GET /parties/MSISDN/123456789`, or `GET /parties/BUSINESS/shoecompany/employee1`).
+      description: >-
+        The HTTP request `GET /parties/{Type}/{ID}` (or `GET
+        /parties/{Type}/{ID}/{SubId}`) is used to look up information regarding
+        the requested Party, defined by `{Type}`, `{ID}` and optionally
+        `{SubId}` (for example, `GET /parties/MSISDN/123456789`, or `GET
+        /parties/BUSINESS/shoecompany/employee1`).
       summary: Look up party information
       tags:
         - parties
       operationId: PartiesSubIdByTypeAndID
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
+        - $ref: '#/components/parameters/Accept'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     put:
-      description: The callback `PUT /parties/{Type}/{ID}` (or `PUT /parties/{Type}/{ID}/{SubId}`) is used to inform the client of a successful result of the Party information lookup.
+      description: >-
+        The callback `PUT /parties/{Type}/{ID}` (or `PUT
+        /parties/{Type}/{ID}/{SubId}`) is used to inform the client of a
+        successful result of the Party information lookup.
       summary: Return party information
       tags:
         - parties
       operationId: PartiesSubIdByTypeAndIDPut
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
+        - $ref: '#/components/parameters/Content-Length'
       requestBody:
         description: Party information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/PartiesTypeIDPutResponse"
+              $ref: '#/components/schemas/PartiesTypeIDPutResponse'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /parties/{Type}/{ID}/{SubId}/error:
     put:
-      description: If the server is unable to find Party information of the provided identity, or another processing error occurred, the error callback `PUT /parties/{Type}/{ID}/error` (or `PUT /parties/{Type}/{ID}/{SubId}/error`) is used.
+      description: >-
+        If the server is unable to find Party information of the provided
+        identity, or another processing error occurred, the error callback `PUT
+        /parties/{Type}/{ID}/error` (or `PUT
+        /parties/{Type}/{ID}/{SubId}/error`) is used.
       summary: Return party information error
       tags:
         - parties
       operationId: PartiesSubIdErrorByTypeAndID
       parameters:
-        #Path
-        - $ref: "#/components/parameters/Type"
-        - $ref: "#/components/parameters/ID"
-        - $ref: "#/components/parameters/SubId"
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/Type'
+        - $ref: '#/components/parameters/ID'
+        - $ref: '#/components/parameters/SubId'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ErrorInformationObject"
+              $ref: '#/components/schemas/ErrorInformationObject'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
-
-  #Transaction requests
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /transactionRequests:
     post:
-      description: The HTTP request `POST /transactionRequests` is used to request the creation of a transaction request for the provided financial transaction in the server.
+      description: >-
+        The HTTP request `POST /transactionRequests` is used to request the
+        creation of a transaction request for the provided financial transaction
+        in the server.
       summary: Perform transaction request
       tags:
         - transactionRequests
       operationId: TransactionRequests
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/Accept'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Transaction request to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TransactionRequestsPostRequest"
+              $ref: '#/components/schemas/TransactionRequestsPostRequest'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /transactionRequests/{ID}:
     parameters:
-      #Path
-      - $ref: "#/components/parameters/ID"
-      #Headers
-      - $ref: "#/components/parameters/Content-Type"
-      - $ref: "#/components/parameters/Date"
-      - $ref: "#/components/parameters/X-Forwarded-For"
-      - $ref: "#/components/parameters/FSPIOP-Source"
-      - $ref: "#/components/parameters/FSPIOP-Destination"
-      - $ref: "#/components/parameters/FSPIOP-Encryption"
-      - $ref: "#/components/parameters/FSPIOP-Signature"
-      - $ref: "#/components/parameters/FSPIOP-URI"
-      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
     get:
-      description: The HTTP request `GET /transactionRequests/{ID}` is used to get information regarding a transaction request created or requested earlier. The `{ID}` in the URI should contain the `transactionRequestId` that was used for the creation of the transaction request.
+      description: >-
+        The HTTP request `GET /transactionRequests/{ID}` is used to get
+        information regarding a transaction request created or requested
+        earlier. The `{ID}` in the URI should contain the `transactionRequestId`
+        that was used for the creation of the transaction request.
       summary: Retrieve transaction request information
       tags:
         - transactionRequests
       operationId: TransactionRequestsByID
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
+        - $ref: '#/components/parameters/Accept'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     put:
-      description: The callback `PUT /transactionRequests/{ID}` is used to inform the client of a requested or created transaction request. The `{ID}` in the URI should contain the `transactionRequestId` that was used for the creation of the transaction request, or the `{ID}` that was used in the `GET /transactionRequests/{ID}`.
+      description: >-
+        The callback `PUT /transactionRequests/{ID}` is used to inform the
+        client of a requested or created transaction request. The `{ID}` in the
+        URI should contain the `transactionRequestId` that was used for the
+        creation of the transaction request, or the `{ID}` that was used in the
+        `GET /transactionRequests/{ID}`.
       summary: Return transaction request information
       tags:
         - transactionRequests
       operationId: TransactionRequestsByIDPut
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
+        - $ref: '#/components/parameters/Content-Length'
       requestBody:
         description: Transaction request information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TransactionRequestsIDPutResponse"
+              $ref: '#/components/schemas/TransactionRequestsIDPutResponse'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /transactionRequests/{ID}/error:
     put:
-      description: If the server is unable to find or create a transaction request, or another processing error occurs, the error callback `PUT /transactionRequests/{ID}/error` is used. The `{ID}` in the URI should contain the `transactionRequestId` that was used for the creation of the transaction request, or the `{ID}` that was used in the `GET /transactionRequests/{ID}`.
+      description: >-
+        If the server is unable to find or create a transaction request, or
+        another processing error occurs, the error callback `PUT
+        /transactionRequests/{ID}/error` is used. The `{ID}` in the URI should
+        contain the `transactionRequestId` that was used for the creation of the
+        transaction request, or the `{ID}` that was used in the `GET
+        /transactionRequests/{ID}`.
       summary: Return transaction request information error
       tags:
         - transactionRequests
       operationId: TransactionRequestsErrorByID
       parameters:
-        #Path
-        - $ref: "#/components/parameters/ID"
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/ID'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ErrorInformationObject"
+              $ref: '#/components/schemas/ErrorInformationObject'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
-
-  #Quotes
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /quotes:
     post:
-      description: The HTTP request `POST /quotes` is used to request the creation of a quote for the provided financial transaction in the server.
+      description: >-
+        The HTTP request `POST /quotes` is used to request the creation of a
+        quote for the provided financial transaction in the server.
       summary: Calculate quote
       tags:
         - quotes
       operationId: Quotes
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/Accept'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the quote to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/QuotesPostRequest"
+              $ref: '#/components/schemas/QuotesPostRequest'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /quotes/{ID}:
     parameters:
-      #Path
-      - $ref: "#/components/parameters/ID"
-      #Headers
-      - $ref: "#/components/parameters/Content-Type"
-      - $ref: "#/components/parameters/Date"
-      - $ref: "#/components/parameters/X-Forwarded-For"
-      - $ref: "#/components/parameters/FSPIOP-Source"
-      - $ref: "#/components/parameters/FSPIOP-Destination"
-      - $ref: "#/components/parameters/FSPIOP-Encryption"
-      - $ref: "#/components/parameters/FSPIOP-Signature"
-      - $ref: "#/components/parameters/FSPIOP-URI"
-      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
     get:
-      description: The HTTP request `GET /quotes/{ID}` is used to get information regarding a quote created or requested earlier. The `{ID}` in the URI should contain the `quoteId` that was used for the creation of the quote.
+      description: >-
+        The HTTP request `GET /quotes/{ID}` is used to get information regarding
+        a quote created or requested earlier. The `{ID}` in the URI should
+        contain the `quoteId` that was used for the creation of the quote.
       summary: Retrieve quote information
       tags:
         - quotes
       operationId: QuotesByID
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
+        - $ref: '#/components/parameters/Accept'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     put:
-      description: The callback `PUT /quotes/{ID}` is used to inform the client of a requested or created quote. The `{ID}` in the URI should contain the `quoteId` that was used for the creation of the quote, or the `{ID}` that was used in the `GET /quotes/{ID}` request.
+      description: >-
+        The callback `PUT /quotes/{ID}` is used to inform the client of a
+        requested or created quote. The `{ID}` in the URI should contain the
+        `quoteId` that was used for the creation of the quote, or the `{ID}`
+        that was used in the `GET /quotes/{ID}` request.
       summary: Return quote information
       tags:
         - quotes
       operationId: QuotesByID1
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
+        - $ref: '#/components/parameters/Content-Length'
       requestBody:
         description: Quote information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/QuotesIDPutResponse"
+              $ref: '#/components/schemas/QuotesIDPutResponse'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /quotes/{ID}/error:
     put:
-      description: If the server is unable to find or create a quote, or some other processing error occurs, the error callback `PUT /quotes/{ID}/error` is used. The `{ID}` in the URI should contain the `quoteId` that was used for the creation of the quote, or the `{ID}` that was used in the `GET /quotes/{ID}` request.
+      description: >-
+        If the server is unable to find or create a quote, or some other
+        processing error occurs, the error callback `PUT /quotes/{ID}/error` is
+        used. The `{ID}` in the URI should contain the `quoteId` that was used
+        for the creation of the quote, or the `{ID}` that was used in the `GET
+        /quotes/{ID}` request.
       summary: Return quote information error
       tags:
         - quotes
       operationId: QuotesByIDAndError
       parameters:
-        #Path
-        - $ref: "#/components/parameters/ID"
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/ID'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ErrorInformationObject"
+              $ref: '#/components/schemas/ErrorInformationObject'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
-
-  #Authorizations
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /authorizations/{ID}:
     parameters:
-      #Path
-      - $ref: "#/components/parameters/ID"
-      #Headers
-      - $ref: "#/components/parameters/Content-Type"
-      - $ref: "#/components/parameters/Date"
-      - $ref: "#/components/parameters/X-Forwarded-For"
-      - $ref: "#/components/parameters/FSPIOP-Source"
-      - $ref: "#/components/parameters/FSPIOP-Destination"
-      - $ref: "#/components/parameters/FSPIOP-Encryption"
-      - $ref: "#/components/parameters/FSPIOP-Signature"
-      - $ref: "#/components/parameters/FSPIOP-URI"
-      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
     get:
-      description:
-        The HTTP request `GET /authorizations/{ID}` is used to request the Payer to enter the applicable credentials in the Payee FSP system. The `{ID}` in the URI should contain the `transactionRequestID`, received from the `POST /transactionRequests` service earlier in the process. This request requires a query string to be included in the URI, with the following key-value pairs*:*
+      description: >-
+        The HTTP request `GET /authorizations/{ID}` is used to request the Payer
+        to enter the applicable credentials in the Payee FSP system. The `{ID}`
+        in the URI should contain the `transactionRequestID`, received from the
+        `POST /transactionRequests` service earlier in the process. This request
+        requires a query string to be included in the URI, with the following
+        key-value pairs*:*
 
 
-        - `authenticationType={Type}`, where `{Type}` value is a valid authentication type from the enumeration `AuthenticationType`.
+        - `authenticationType={Type}`, where `{Type}` value is a valid
+        authentication type from the enumeration `AuthenticationType`.
 
 
-        - `retriesLeft=={NrOfRetries}`, where `{NrOfRetries}` is the number of retries left before the financial transaction is rejected. `{NrOfRetries}` must be expressed in the form of the data type `Integer`. `retriesLeft=1` means that this is the last retry before the financial transaction is rejected.
+        - `retriesLeft=={NrOfRetries}`, where `{NrOfRetries}` is the number of
+        retries left before the financial transaction is rejected.
+        `{NrOfRetries}` must be expressed in the form of the data type
+        `Integer`. `retriesLeft=1` means that this is the last retry before the
+        financial transaction is rejected.
 
 
-        - `amount={Amount}`, where `{Amount}` is the transaction amount that will be withdrawn from the Payer’s account. `{Amount}` must be expressed in the form of the data type `Amount`.
+        - `amount={Amount}`, where `{Amount}` is the transaction amount that
+        will be withdrawn from the Payer’s account. `{Amount}` must be expressed
+        in the form of the data type `Amount`.
 
 
-        - `currency={Currency}`, where `{Currency}` is the transaction currency for the amount that will be withdrawn from the Payer’s account. The `{Currency}` value must be expressed in the form of the enumeration `CurrencyCode`.
+        - `currency={Currency}`, where `{Currency}` is the transaction currency
+        for the amount that will be withdrawn from the Payer’s account. The
+        `{Currency}` value must be expressed in the form of the enumeration
+        `CurrencyCode`.
 
 
-        The following is an example URI containing all the required key-value pairs in the query string*:*
+        The following is an example URI containing all the required key-value
+        pairs in the query string*:*
 
 
-        `GET /authorization/3d492671-b7af-4f3f-88de-76169b1bdf88?authenticationType=OTP&retriesLeft=2&amount=102&currency=USD`
+        `GET
+        /authorization/3d492671-b7af-4f3f-88de-76169b1bdf88?authenticationType=OTP&retriesLeft=2&amount=102&currency=USD`
       summary: Perform authorization
       tags:
         - authorizations
       operationId: AuthorizationsByIDGet
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
+        - $ref: '#/components/parameters/Accept'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     put:
-      description: The callback `PUT /authorizations/{ID}` is used to inform the client of the result of a previously-requested authorization. The `{ID}` in the URI should contain the `{ID}` that was used in the `GET /authorizations/{ID}` request.
+      description: >-
+        The callback `PUT /authorizations/{ID}` is used to inform the client of
+        the result of a previously-requested authorization. The `{ID}` in the
+        URI should contain the `{ID}` that was used in the `GET
+        /authorizations/{ID}` request.
       summary: Return authorization result
       tags:
         - authorizations
       operationId: AuthorizationsByIDPut
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
+        - $ref: '#/components/parameters/Content-Length'
       requestBody:
         description: Authorization result returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AuthorizationsIDPutResponse"
+              $ref: '#/components/schemas/AuthorizationsIDPutResponse'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /authorizations/{ID}/error:
     put:
-      description: If the server is unable to find the transaction request, or another processing error occurs, the error callback `PUT /authorizations/{ID}/error` is used. The `{ID}` in the URI should contain the `{ID}` that was used in the `GET /authorizations/{ID}`.
+      description: >-
+        If the server is unable to find the transaction request, or another
+        processing error occurs, the error callback `PUT
+        /authorizations/{ID}/error` is used. The `{ID}` in the URI should
+        contain the `{ID}` that was used in the `GET /authorizations/{ID}`.
       summary: Return authorization error
       tags:
         - authorizations
       operationId: AuthorizationsByIDAndError
       parameters:
-        #Path
-        - $ref: "#/components/parameters/ID"
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/ID'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ErrorInformationObject"
+              $ref: '#/components/schemas/ErrorInformationObject'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
-
-  #Transfers
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /transfers:
     post:
-      description: The HTTP request `POST /transfers` is used to request the creation of a transfer for the next ledger, and a financial transaction for the Payee FSP.
+      description: >-
+        The HTTP request `POST /transfers` is used to request the creation of a
+        transfer for the next ledger, and a financial transaction for the Payee
+        FSP.
       summary: Perform transfer
       tags:
         - transfers
       operationId: transfers
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/Accept'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the transfer to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TransfersPostRequest"
+              $ref: '#/components/schemas/TransfersPostRequest'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /transfers/{ID}:
     parameters:
-      #Path
-      - $ref: "#/components/parameters/ID"
-      #Headers
-      - $ref: "#/components/parameters/Content-Type"
-      - $ref: "#/components/parameters/Date"
-      - $ref: "#/components/parameters/X-Forwarded-For"
-      - $ref: "#/components/parameters/FSPIOP-Source"
-      - $ref: "#/components/parameters/FSPIOP-Destination"
-      - $ref: "#/components/parameters/FSPIOP-Encryption"
-      - $ref: "#/components/parameters/FSPIOP-Signature"
-      - $ref: "#/components/parameters/FSPIOP-URI"
-      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
     get:
-      description: The HTTP request `GET /transfers/{ID}` is used to get information regarding a transfer created or requested earlier. The `{ID}` in the URI should contain the `transferId` that was used for the creation of the transfer.
+      description: >-
+        The HTTP request `GET /transfers/{ID}` is used to get information
+        regarding a transfer created or requested earlier. The `{ID}` in the URI
+        should contain the `transferId` that was used for the creation of the
+        transfer.
       summary: Retrieve transfer information
       tags:
         - transfers
       operationId: TransfersByIDGet
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
+        - $ref: '#/components/parameters/Accept'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     patch:
-      description: The HTTP request PATCH /transfers/<ID> is used by a Switch to update the state of a previously reserved transfer, if the Payee FSP has requested a commit notification when the Switch has completed processing of the transfer. The <ID> in the URI should contain the transferId that was used for the creation of the transfer. Please note that this request does not generate a callback.
+      description: >-
+        The HTTP request PATCH /transfers/<ID> is used by a Switch to update the
+        state of a previously reserved transfer, if the Payee FSP has requested
+        a commit notification when the Switch has completed processing of the
+        transfer. The <ID> in the URI should contain the transferId that was
+        used for the creation of the transfer. Please note that this request
+        does not generate a callback.
       summary: Return transfer information
       tags:
         - transfers
       operationId: TransfersByIDPatch
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
+        - $ref: '#/components/parameters/Content-Length'
       requestBody:
         description: Transfer notification upon completion.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TransfersIDPatchResponse"
+              $ref: '#/components/schemas/TransfersIDPatchResponse'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     put:
-      description: The callback `PUT /transfers/{ID}` is used to inform the client of a requested or created transfer. The `{ID}` in the URI should contain the `transferId` that was used for the creation of the transfer, or the `{ID}` that was used in the `GET /transfers/{ID}` request.
+      description: >-
+        The callback `PUT /transfers/{ID}` is used to inform the client of a
+        requested or created transfer. The `{ID}` in the URI should contain the
+        `transferId` that was used for the creation of the transfer, or the
+        `{ID}` that was used in the `GET /transfers/{ID}` request.
       summary: Return transfer information
       tags:
         - transfers
       operationId: TransfersByIDPut
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
+        - $ref: '#/components/parameters/Content-Length'
       requestBody:
         description: Transfer information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TransfersIDPutResponse"
+              $ref: '#/components/schemas/TransfersIDPutResponse'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /transfers/{ID}/error:
     put:
-      description: If the server is unable to find or create a transfer, or another processing error occurs, the error callback `PUT /transfers/{ID}/error` is used. The `{ID}` in the URI should contain the `transferId` that was used for the creation of the transfer, or the `{ID}` that was used in the `GET /transfers/{ID}`.
+      description: >-
+        If the server is unable to find or create a transfer, or another
+        processing error occurs, the error callback `PUT /transfers/{ID}/error`
+        is used. The `{ID}` in the URI should contain the `transferId` that was
+        used for the creation of the transfer, or the `{ID}` that was used in
+        the `GET /transfers/{ID}`.
       summary: Return transfer information error
       tags:
         - transfers
       operationId: TransfersByIDAndError
       parameters:
-        #Path
-        - $ref: "#/components/parameters/ID"
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/ID'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ErrorInformationObject"
+              $ref: '#/components/schemas/ErrorInformationObject'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
-
-  #Transactions
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /transactions/{ID}:
     parameters:
-      - $ref: "#/components/parameters/ID"
-      #Headers
-      - $ref: "#/components/parameters/Content-Type"
-      - $ref: "#/components/parameters/Date"
-      - $ref: "#/components/parameters/X-Forwarded-For"
-      - $ref: "#/components/parameters/FSPIOP-Source"
-      - $ref: "#/components/parameters/FSPIOP-Destination"
-      - $ref: "#/components/parameters/FSPIOP-Encryption"
-      - $ref: "#/components/parameters/FSPIOP-Signature"
-      - $ref: "#/components/parameters/FSPIOP-URI"
-      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
     get:
-      description: The HTTP request `GET /transactions/{ID}` is used to get transaction information regarding a financial transaction created earlier. The `{ID}` in the URI should contain the `transactionId` that was used for the creation of the quote, as the transaction is created as part of another process (the transfer process).
+      description: >-
+        The HTTP request `GET /transactions/{ID}` is used to get transaction
+        information regarding a financial transaction created earlier. The
+        `{ID}` in the URI should contain the `transactionId` that was used for
+        the creation of the quote, as the transaction is created as part of
+        another process (the transfer process).
       summary: Retrieve transaction information
       tags:
         - transactions
       operationId: TransactionsByID
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
+        - $ref: '#/components/parameters/Accept'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     put:
-      description: The callback `PUT /transactions/{ID}` is used to inform the client of a requested transaction. The `{ID}` in the URI should contain the `{ID}` that was used in the `GET /transactions/{ID}` request.
+      description: >-
+        The callback `PUT /transactions/{ID}` is used to inform the client of a
+        requested transaction. The `{ID}` in the URI should contain the `{ID}`
+        that was used in the `GET /transactions/{ID}` request.
       summary: Return transaction information
       tags:
         - transactions
       operationId: TransactionsByID1
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
+        - $ref: '#/components/parameters/Content-Length'
       requestBody:
         description: Transaction information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/TransactionsIDPutResponse"
+              $ref: '#/components/schemas/TransactionsIDPutResponse'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /transactions/{ID}/error:
     put:
-      description: If the server is unable to find or create a transaction, or another processing error occurs, the error callback `PUT /transactions/{ID}/error` is used. The `{ID}` in the URI should contain the `{ID}` that was used in the `GET /transactions/{ID}` request.
+      description: >-
+        If the server is unable to find or create a transaction, or another
+        processing error occurs, the error callback `PUT
+        /transactions/{ID}/error` is used. The `{ID}` in the URI should contain
+        the `{ID}` that was used in the `GET /transactions/{ID}` request.
       summary: Return transaction information error
       tags:
         - transactions
       operationId: TransactionsErrorByID
       parameters:
-        #Path
-        - $ref: "#/components/parameters/ID"
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/ID'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ErrorInformationObject"
+              $ref: '#/components/schemas/ErrorInformationObject'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
-
-  #Bulk Quotes
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /bulkQuotes:
     post:
-      description: The HTTP request `POST /bulkQuotes` is used to request the creation of a bulk quote for the provided financial transactions in the server.
+      description: >-
+        The HTTP request `POST /bulkQuotes` is used to request the creation of a
+        bulk quote for the provided financial transactions in the server.
       summary: Calculate bulk quote
       tags:
         - bulkQuotes
       operationId: BulkQuotes
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/Accept'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the bulk quote to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/BulkQuotesPostRequest"
+              $ref: '#/components/schemas/BulkQuotesPostRequest'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /bulkQuotes/{ID}:
     parameters:
-      #Path
-      - $ref: "#/components/parameters/ID"
-      #Headers
-      - $ref: "#/components/parameters/Content-Type"
-      - $ref: "#/components/parameters/Date"
-      - $ref: "#/components/parameters/X-Forwarded-For"
-      - $ref: "#/components/parameters/FSPIOP-Source"
-      - $ref: "#/components/parameters/FSPIOP-Destination"
-      - $ref: "#/components/parameters/FSPIOP-Encryption"
-      - $ref: "#/components/parameters/FSPIOP-Signature"
-      - $ref: "#/components/parameters/FSPIOP-URI"
-      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
     get:
-      description: The HTTP request `GET /bulkQuotes/{ID}` is used to get information regarding a bulk quote created or requested earlier. The `{ID}` in the URI should contain the `bulkQuoteId` that was used for the creation of the bulk quote.
+      description: >-
+        The HTTP request `GET /bulkQuotes/{ID}` is used to get information
+        regarding a bulk quote created or requested earlier. The `{ID}` in the
+        URI should contain the `bulkQuoteId` that was used for the creation of
+        the bulk quote.
       summary: Retrieve bulk quote information
       tags:
         - bulkQuotes
       operationId: BulkQuotesByID
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
+        - $ref: '#/components/parameters/Accept'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     put:
-      description: The callback `PUT /bulkQuotes/{ID}` is used to inform the client of a requested or created bulk quote. The `{ID}` in the URI should contain the `bulkQuoteId` that was used for the creation of the bulk quote, or the `{ID}` that was used in the `GET /bulkQuotes/{ID}` request.
+      description: >-
+        The callback `PUT /bulkQuotes/{ID}` is used to inform the client of a
+        requested or created bulk quote. The `{ID}` in the URI should contain
+        the `bulkQuoteId` that was used for the creation of the bulk quote, or
+        the `{ID}` that was used in the `GET /bulkQuotes/{ID}` request.
       summary: Return bulk quote information
       tags:
         - bulkQuotes
       operationId: BulkQuotesByID1
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
+        - $ref: '#/components/parameters/Content-Length'
       requestBody:
         description: Bulk quote information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/BulkQuotesIDPutResponse"
+              $ref: '#/components/schemas/BulkQuotesIDPutResponse'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /bulkQuotes/{ID}/error:
     put:
-      description: If the server is unable to find or create a bulk quote, or another processing error occurs, the error callback `PUT /bulkQuotes/{ID}/error` is used. The `{ID}` in the URI should contain the `bulkQuoteId` that was used for the creation of the bulk quote, or the `{ID}` that was used in the `GET /bulkQuotes/{ID}` request.
+      description: >-
+        If the server is unable to find or create a bulk quote, or another
+        processing error occurs, the error callback `PUT /bulkQuotes/{ID}/error`
+        is used. The `{ID}` in the URI should contain the `bulkQuoteId` that was
+        used for the creation of the bulk quote, or the `{ID}` that was used in
+        the `GET /bulkQuotes/{ID}` request.
       summary: Return bulk quote information error
       tags:
         - bulkQuotes
       operationId: BulkQuotesErrorByID
       parameters:
-        #Path
-        - $ref: "#/components/parameters/ID"
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/ID'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ErrorInformationObject"
+              $ref: '#/components/schemas/ErrorInformationObject'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
-
-  #Bulk transfers
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /bulkTransfers:
     post:
-      description: The HTTP request `POST /bulkTransfers` is used to request the creation of a bulk transfer in the server.
+      description: >-
+        The HTTP request `POST /bulkTransfers` is used to request the creation
+        of a bulk transfer in the server.
       summary: Perform bulk transfer
       tags:
         - bulkTransfers
       operationId: BulkTransfers
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/Accept'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the bulk transfer to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/BulkTransfersPostRequest"
+              $ref: '#/components/schemas/BulkTransfersPostRequest'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /bulkTransfers/{ID}:
     parameters:
-      #Path
-      - $ref: "#/components/parameters/ID"
-      #Headers
-      - $ref: "#/components/parameters/Content-Type"
-      - $ref: "#/components/parameters/Date"
-      - $ref: "#/components/parameters/X-Forwarded-For"
-      - $ref: "#/components/parameters/FSPIOP-Source"
-      - $ref: "#/components/parameters/FSPIOP-Destination"
-      - $ref: "#/components/parameters/FSPIOP-Encryption"
-      - $ref: "#/components/parameters/FSPIOP-Signature"
-      - $ref: "#/components/parameters/FSPIOP-URI"
-      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+      - $ref: '#/components/parameters/ID'
+      - $ref: '#/components/parameters/Content-Type'
+      - $ref: '#/components/parameters/Date'
+      - $ref: '#/components/parameters/X-Forwarded-For'
+      - $ref: '#/components/parameters/FSPIOP-Source'
+      - $ref: '#/components/parameters/FSPIOP-Destination'
+      - $ref: '#/components/parameters/FSPIOP-Encryption'
+      - $ref: '#/components/parameters/FSPIOP-Signature'
+      - $ref: '#/components/parameters/FSPIOP-URI'
+      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
     get:
-      description: The HTTP request `GET /bulkTransfers/{ID}` is used to get information regarding a bulk transfer created or requested earlier. The `{ID}` in the URI should contain the `bulkTransferId` that was used for the creation of the bulk transfer.
+      description: >-
+        The HTTP request `GET /bulkTransfers/{ID}` is used to get information
+        regarding a bulk transfer created or requested earlier. The `{ID}` in
+        the URI should contain the `bulkTransferId` that was used for the
+        creation of the bulk transfer.
       summary: Retrieve bulk transfer information
       tags:
         - bulkTransfers
       operationId: BulkTransferByID
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Accept"
+        - $ref: '#/components/parameters/Accept'
       responses:
-        202:
-          $ref: "#/components/responses/202"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '202':
+          $ref: '#/components/responses/202'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
     put:
-      description: The callback `PUT /bulkTransfers/{ID}` is used to inform the client of a requested or created bulk transfer. The `{ID}` in the URI should contain the `bulkTransferId` that was used for the creation of the bulk transfer (`POST /bulkTransfers`), or the `{ID}` that was used in the `GET /bulkTransfers/{ID}` request.
+      description: >-
+        The callback `PUT /bulkTransfers/{ID}` is used to inform the client of a
+        requested or created bulk transfer. The `{ID}` in the URI should contain
+        the `bulkTransferId` that was used for the creation of the bulk transfer
+        (`POST /bulkTransfers`), or the `{ID}` that was used in the `GET
+        /bulkTransfers/{ID}` request.
       summary: Return bulk transfer information
       tags:
         - bulkTransfers
       operationId: BulkTransfersByIDPut
       parameters:
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
+        - $ref: '#/components/parameters/Content-Length'
       requestBody:
         description: Bulk transfer information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/BulkTransfersIDPutResponse"
+              $ref: '#/components/schemas/BulkTransfersIDPutResponse'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
   /bulkTransfers/{ID}/error:
     put:
-      description: If the server is unable to find or create a bulk transfer, or another processing error occurs, the error callback `PUT /bulkTransfers/{ID}/error` is used. The `{ID}` in the URI should contain the `bulkTransferId` that was used for the creation of the bulk transfer (`POST /bulkTransfers`), or the `{ID}` that was used in the `GET /bulkTransfers/{ID}` request.
+      description: >-
+        If the server is unable to find or create a bulk transfer, or another
+        processing error occurs, the error callback `PUT
+        /bulkTransfers/{ID}/error` is used. The `{ID}` in the URI should contain
+        the `bulkTransferId` that was used for the creation of the bulk transfer
+        (`POST /bulkTransfers`), or the `{ID}` that was used in the `GET
+        /bulkTransfers/{ID}` request.
       summary: Return bulk transfer information error
       tags:
         - bulkTransfers
       operationId: BulkTransfersErrorByID
       parameters:
-        #Path
-        - $ref: "#/components/parameters/ID"
-        #Headers
-        - $ref: "#/components/parameters/Content-Length"
-        - $ref: "#/components/parameters/Content-Type"
-        - $ref: "#/components/parameters/Date"
-        - $ref: "#/components/parameters/X-Forwarded-For"
-        - $ref: "#/components/parameters/FSPIOP-Source"
-        - $ref: "#/components/parameters/FSPIOP-Destination"
-        - $ref: "#/components/parameters/FSPIOP-Encryption"
-        - $ref: "#/components/parameters/FSPIOP-Signature"
-        - $ref: "#/components/parameters/FSPIOP-URI"
-        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
+        - $ref: '#/components/parameters/ID'
+        - $ref: '#/components/parameters/Content-Length'
+        - $ref: '#/components/parameters/Content-Type'
+        - $ref: '#/components/parameters/Date'
+        - $ref: '#/components/parameters/X-Forwarded-For'
+        - $ref: '#/components/parameters/FSPIOP-Source'
+        - $ref: '#/components/parameters/FSPIOP-Destination'
+        - $ref: '#/components/parameters/FSPIOP-Encryption'
+        - $ref: '#/components/parameters/FSPIOP-Signature'
+        - $ref: '#/components/parameters/FSPIOP-URI'
+        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ErrorInformationObject"
+              $ref: '#/components/schemas/ErrorInformationObject'
       responses:
-        200:
-          $ref: "#/components/responses/200"
-        400:
-          $ref: "#/components/responses/400"
-        401:
-          $ref: "#/components/responses/401"
-        403:
-          $ref: "#/components/responses/403"
-        404:
-          $ref: "#/components/responses/404"
-        405:
-          $ref: "#/components/responses/405"
-        406:
-          $ref: "#/components/responses/406"
-        501:
-          $ref: "#/components/responses/501"
-        503:
-          $ref: "#/components/responses/503"
-
+        '200':
+          $ref: '#/components/responses/200'
+        '400':
+          $ref: '#/components/responses/400'
+        '401':
+          $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          $ref: '#/components/responses/404'
+        '405':
+          $ref: '#/components/responses/405'
+        '406':
+          $ref: '#/components/responses/406'
+        '501':
+          $ref: '#/components/responses/501'
+        '503':
+          $ref: '#/components/responses/503'
 components:
   schemas:
-    #Element definitions
-    Amount:
-      title: Amount
-      type: string
-      pattern: ^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$
-      description: The API data type Amount is a JSON String in a canonical format that is restricted by a regular expression for interoperability reasons. This pattern does not allow any trailing zeroes at all, but allows an amount without a minor currency unit. It also only allows four digits in the minor currency unit; a negative value is not allowed. Using more than 18 digits in the major currency unit is not allowed.
-    AmountType:
-      title: AmountType
-      type: string
-      enum:
-        - SEND
-        - RECEIVE
-      description: Below are the allowed values for the enumeration AmountType.
-
-        - SEND - Amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees.
-
-        - RECEIVE - Amount the Payer would like the Payee to receive, that is, the amount that should be sent to the receiver exclusive of any fees.
-    AuthenticationType:
-      title: AuthenticationType
-      type: string
-      enum:
-        - OTP
-        - QRCODE
-      description:
-        Below are the allowed values for the enumeration AuthenticationType.
-
-        - OTP - One-time password generated by the Payer FSP.
-
-        - QRCODE - QR code used as One Time Password.
-    AuthenticationValue:
-      title: AuthenticationValue
-      oneOf:
-        - $ref: "#/components/schemas/OtpValue"
-        - $ref: "#/components/schemas/QRCODE"
-      pattern: ^\d{3,10}$|^\S{1,64}$
-      description: Contains the authentication value. The format depends on the authentication type used in the AuthenticationInfo complex type.
-    AuthorizationResponse:
-      title: AuthorizationResponse
-      type: string
-      enum:
-        - ENTERED
-        - REJECTED
-        - RESEND
-      description: Below are the allowed values for the enumeration.
-
-        - ENTERED - Consumer entered the authentication value.
-
-        - REJECTED - Consumer rejected the transaction.
-
-        - RESEND - Consumer requested to resend the authentication value.
-    BalanceOfPayments:
-      title: BalanceOfPayments
-      type: string
-      pattern: ^[1-9]\d{2}$
-      description: (BopCode) The API data type [BopCode](https://www.imf.org/external/np/sta/bopcode/) is a JSON String of 3 characters, consisting of digits only. Negative numbers are not allowed. A leading zero is not allowed.
     BinaryString:
       type: string
       pattern: ^[A-Za-z0-9-_]+[=]{0,2}$
-      description: The API data type BinaryString is a JSON String. The string is a base64url  encoding of a string of raw bytes, where padding (character ‘=’) is added at the end of the data if needed to ensure that the string is a multiple of 4 characters. The length restriction indicates the allowed number of characters.
+      description: >-
+        The API data type BinaryString is a JSON String. The string is a
+        base64url  encoding of a string of raw bytes, where padding (character
+        ‘=’) is added at the end of the data if needed to ensure that the string
+        is a multiple of 4 characters. The length restriction indicates the
+        allowed number of characters.
     BinaryString32:
       type: string
       pattern: ^[A-Za-z0-9-_]{43}$
-      description: The API data type BinaryString32 is a fixed size version of the API data type BinaryString, where the raw underlying data is always of 32 bytes. The data type BinaryString32 should not use a padding character as the size of the underlying data is fixed.
-    BulkTransferState:
-      title: BulkTransactionState
+      description: >-
+        The API data type BinaryString32 is a fixed size version of the API data
+        type BinaryString, where the raw underlying data is always of 32 bytes.
+        The data type BinaryString32 should not use a padding character as the
+        size of the underlying data is fixed.
+    Date:
+      title: Date
+      type: string
+      pattern: >-
+        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
+      description: >-
+        The API data type Date is a JSON String in a lexical format that is
+        restricted by a regular expression for interoperability reasons. This
+        format, as specified in ISO 8601, contains a date only. A more readable
+        version of the format is yyyy-MM-dd. Examples are "1982-05-23",
+        "1987-08-05”.
+    Integer:
+      title: Integer
+      type: string
+      pattern: ^[1-9]\d*$
+      description: >-
+        The API data type Integer is a JSON String consisting of digits only.
+        Negative numbers and leading zeroes are not allowed. The data type is
+        always limited to a specific number of digits.
+    Name:
+      title: Name
+      type: string
+      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
+      description: >-
+        The API data type Name is a JSON String, restricted by a regular
+        expression to avoid characters which are generally not used in a name.
+
+
+        Regular Expression - The regular expression for restricting the Name
+        type is "^(?!\s*$)[\w .,'-]{1,128}$". The restriction does not allow a
+        string consisting of whitespace only, all Unicode characters are
+        allowed, as well as the period (.) (apostrophe (‘), dash (-), comma (,)
+        and space characters ( ).
+
+
+        **Note:** In some programming languages, Unicode support must be
+        specifically enabled. For example, if Java is used, the flag
+        UNICODE_CHARACTER_CLASS must be enabled to allow Unicode characters.
+    PersonalIdentifierType:
+      title: PersonalIdentifierType
       type: string
       enum:
-        - RECEIVED
-        - PENDING
-        - ACCEPTED
-        - PROCESSING
-        - COMPLETED
-        - REJECTED
-      description: Below are the allowed values for the enumeration.
+        - PASSPORT
+        - NATIONAL_REGISTRATION
+        - DRIVING_LICENSE
+        - ALIEN_REGISTRATION
+        - NATIONAL_ID_CARD
+        - EMPLOYER_ID
+        - TAX_ID_NUMBER
+        - SENIOR_CITIZENS_CARD
+        - MARRIAGE_CERTIFICATE
+        - HEALTH_CARD
+        - VOTERS_ID
+        - UNITED_NATIONS
+        - OTHER_ID
+      description: >-
+        Below are the allowed values for the enumeration.
 
-        - RECEIVED - Payee FSP has received the bulk transfer from the Payer FSP.
+        - PASSPORT - A passport number is used as reference to a Party.
 
-        - PENDING - Payee FSP has validated the bulk transfer.
+        - NATIONAL_REGISTRATION - A national registration number is used as
+        reference to a Party.
 
-        - ACCEPTED - Payee FSP has accepted to process the bulk transfer.
+        - DRIVING_LICENSE - A driving license is used as reference to a Party.
 
-        - PROCESSING - Payee FSP has started to transfer fund to the Payees.
+        - ALIEN_REGISTRATION - An alien registration number is used as reference
+        to a Party.
 
-        - COMPLETED - Payee FSP has completed transfer of funds to the Payees.
+        - NATIONAL_ID_CARD - A national ID card number is used as reference to a
+        Party.
 
-        - REJECTED - Payee FSP has rejected to process the bulk transfer.
-    Code:
-      title: Code
+        - EMPLOYER_ID - A tax identification number is used as reference to a
+        Party.
+
+        - TAX_ID_NUMBER - A tax identification number is used as reference to a
+        Party.
+
+        - SENIOR_CITIZENS_CARD - A senior citizens card number is used as
+        reference to a Party.
+
+        - MARRIAGE_CERTIFICATE - A marriage certificate number is used as
+        reference to a Party.
+
+        - HEALTH_CARD - A health card number is used as reference to a Party.
+
+        - VOTERS_ID - A voter’s identification number is used as reference to a
+        Party.
+
+        - UNITED_NATIONS - An UN (United Nations) number is used as reference to
+        a Party.
+
+        - OTHER_ID - Any other type of identification type number is used as
+        reference to a Party.
+    TokenCode:
+      title: TokenCode
       type: string
       pattern: ^[0-9a-zA-Z]{4,32}$
-      description: Any code/token returned by the Payee FSP (TokenCode Type).
+      description: >-
+        The API data type TokenCode is a JSON String between 4 and 32
+        characters, consisting of digits or upper- or lowercase characters from
+        a to z.
     CorrelationId:
       title: CorrelationId
       type: string
-      pattern: ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
-      description: Identifier that correlates all messages of the same sequence. The API data type UUID (Universally Unique Identifier) is a JSON String in canonical format, conforming to [RFC 4122](https://tools.ietf.org/html/rfc4122), that is restricted by a regular expression for interoperability reasons. A UUID is always 36 characters long, 32 hexadecimal symbols and 4 dashes (‘-‘).
+      pattern: >-
+        ^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
+      description: >-
+        Identifier that correlates all messages of the same sequence. The API
+        data type UUID (Universally Unique Identifier) is a JSON String in
+        canonical format, conforming to [RFC
+        4122](https://tools.ietf.org/html/rfc4122), that is restricted by a
+        regular expression for interoperability reasons. A UUID is always 36
+        characters long, 32 hexadecimal symbols and 4 dashes (‘-‘).
+      example: b51ec534-ee48-4575-b6a9-ead2955b8069
+    PartyIdType:
+      title: PartyIdType
+      type: string
+      enum:
+        - MSISDN
+        - EMAIL
+        - PERSONAL_ID
+        - BUSINESS
+        - DEVICE
+        - ACCOUNT_ID
+        - IBAN
+        - ALIAS
+      description: >-
+        Below are the allowed values for the enumeration.
+
+        - MSISDN - An MSISDN (Mobile Station International Subscriber Directory
+        Number, that is, the phone number) is used as reference to a
+        participant. The MSISDN identifier should be in international format
+        according to the [ITU-T E.164
+        standard](https://www.itu.int/rec/T-REC-E.164/en). Optionally, the
+        MSISDN may be prefixed by a single plus sign, indicating the
+        international prefix.
+
+        - EMAIL - An email is used as reference to a participant. The format of
+        the email should be according to the informational [RFC
+        3696](https://tools.ietf.org/html/rfc3696).
+
+        - PERSONAL_ID - A personal identifier is used as reference to a
+        participant. Examples of personal identification are passport number,
+        birth certificate number, and national registration number. The
+        identifier number is added in the PartyIdentifier element. The personal
+        identifier type is added in the PartySubIdOrType element.
+
+        - BUSINESS - A specific Business (for example, an organization or a
+        company) is used as reference to a participant. The BUSINESS identifier
+        can be in any format. To make a transaction connected to a specific
+        username or bill number in a Business, the PartySubIdOrType element
+        should be used.
+
+        - DEVICE - A specific device (for example, a POS or ATM) ID connected to
+        a specific business or organization is used as reference to a Party. For
+        referencing a specific device under a specific business or organization,
+        use the PartySubIdOrType element.
+
+        - ACCOUNT_ID - A bank account number or FSP account ID should be used as
+        reference to a participant. The ACCOUNT_ID identifier can be in any
+        format, as formats can greatly differ depending on country and FSP.
+
+        - IBAN - A bank account number or FSP account ID is used as reference to
+        a participant. The IBAN identifier can consist of up to 34 alphanumeric
+        characters and should be entered without whitespace.
+
+        - ALIAS An alias is used as reference to a participant. The alias should
+        be created in the FSP as an alternative reference to an account owner.
+        Another example of an alias is a username in the FSP system. The ALIAS
+        identifier can be in any format. It is also possible to use the
+        PartySubIdOrType element for identifying an account under an Alias
+        defined by the PartyIdentifier.
+    PartyIdentifier:
+      title: PartyIdentifier
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Identifier of the Party.
+      example: '16135551212'
+    PartySubIdOrType:
+      title: PartySubIdOrType
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: >-
+        Either a sub-identifier of a PartyIdentifier, or a sub-type of the
+        PartyIdType, normally a PersonalIdentifierType.
+    FspId:
+      title: FspId
+      type: string
+      minLength: 1
+      maxLength: 32
+      description: FSP identifier.
+    ExtensionKey:
+      title: ExtensionKey
+      type: string
+      minLength: 1
+      maxLength: 32
+      description: Extension key.
+    ExtensionValue:
+      title: ExtensionValue
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Extension value.
+    Extension:
+      title: Extension
+      type: object
+      description: Data model for the complex type Extension.
+      properties:
+        key:
+          $ref: '#/components/schemas/ExtensionKey'
+        value:
+          $ref: '#/components/schemas/ExtensionValue'
+      required:
+        - key
+        - value
+    ExtensionList:
+      title: ExtensionList
+      type: object
+      description: >-
+        Data model for the complex type ExtensionList. An optional list of
+        extensions, specific to deployment.
+      properties:
+        extension:
+          type: array
+          items:
+            $ref: '#/components/schemas/Extension'
+          minItems: 1
+          maxItems: 16
+          description: Number of Extension elements.
+      required:
+        - extension
+    PartyIdInfo:
+      title: PartyIdInfo
+      type: object
+      description: >-
+        Data model for the complex type PartyIdInfo. An ExtensionList element
+        has been added to this reqeust in version v1.1
+      properties:
+        partyIdType:
+          $ref: '#/components/schemas/PartyIdType'
+        partyIdentifier:
+          $ref: '#/components/schemas/PartyIdentifier'
+        partySubIdOrType:
+          $ref: '#/components/schemas/PartySubIdOrType'
+        fspId:
+          $ref: '#/components/schemas/FspId'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - partyIdType
+        - partyIdentifier
+    MerchantClassificationCode:
+      title: MerchantClassificationCode
+      type: string
+      pattern: ^[\d]{1,4}$
+      description: >-
+        A limited set of pre-defined numbers. This list would be a limited set
+        of numbers identifying a set of popular merchant types like School Fees,
+        Pubs and Restaurants, Groceries, etc.
+    PartyName:
+      title: PartyName
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Name of the Party. Could be a real name or a nickname.
+    FirstName:
+      title: FirstName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: >-
+        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
+        .,''-]{1,128}$
+      description: First name of the Party (Name Type).
+      example: Henrik
+    MiddleName:
+      title: MiddleName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: >-
+        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
+        .,''-]{1,128}$
+      description: Middle name of the Party (Name Type).
+      example: Johannes
+    LastName:
+      title: LastName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: >-
+        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
+        .,''-]{1,128}$
+      description: Last name of the Party (Name Type).
+      example: Karlsson
+    PartyComplexName:
+      title: PartyComplexName
+      type: object
+      description: Data model for the complex type PartyComplexName.
+      properties:
+        firstName:
+          $ref: '#/components/schemas/FirstName'
+        middleName:
+          $ref: '#/components/schemas/MiddleName'
+        lastName:
+          $ref: '#/components/schemas/LastName'
+    DateOfBirth:
+      title: DateofBirth (type Date)
+      type: string
+      pattern: >-
+        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
+      description: Date of Birth of the Party.
+      example: '1966-06-16'
+    PartyPersonalInfo:
+      title: PartyPersonalInfo
+      type: object
+      description: Data model for the complex type PartyPersonalInfo.
+      properties:
+        complexName:
+          $ref: '#/components/schemas/PartyComplexName'
+        dateOfBirth:
+          $ref: '#/components/schemas/DateOfBirth'
+    Party:
+      title: Party
+      type: object
+      description: Data model for the complex type Party.
+      properties:
+        partyIdInfo:
+          $ref: '#/components/schemas/PartyIdInfo'
+        merchantClassificationCode:
+          $ref: '#/components/schemas/MerchantClassificationCode'
+        name:
+          $ref: '#/components/schemas/PartyName'
+        personalInfo:
+          $ref: '#/components/schemas/PartyPersonalInfo'
+      required:
+        - partyIdInfo
     Currency:
       title: Currency
-      description: The currency codes defined in [ISO 4217](https://www.iso.org/iso-4217-currency-codes.html) as three-letter alphabetic codes are used as the standard naming representation for currencies.
+      description: >-
+        The currency codes defined in [ISO
+        4217](https://www.iso.org/iso-4217-currency-codes.html) as three-letter
+        alphabetic codes are used as the standard naming representation for
+        currencies.
       type: string
       minLength: 3
       maxLength: 3
@@ -2239,294 +2630,36 @@ components:
         - XDR
         - XOF
         - XPF
+        - XTS
+        - XXX
         - YER
         - ZAR
         - ZMW
         - ZWD
-    Date:
-      title: Date
+    Amount:
+      title: Amount
       type: string
-      pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
-      description:
-        The API data type Date is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
-        This format, as specified in ISO 8601, contains a date only. A more readable version of the format is yyyy-MM-dd. Examples are "1982-05-23", "1987-08-05”.
-    DateOfBirth:
-      title: DateofBirth (type Date)
-      type: string
-      pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
-      description: Date of Birth of the Party.
-    DateTime:
-      title: DateTime
-      type: string
-      pattern: ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$
-      description:
-        The API data type DateTime is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
-        The format is according to [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html), expressed in a combined date, time and time zone format. A more readable version of the format is yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]. Examples are "2016-05-24T08:38:08.699-04:00", "2016-05-24T08:38:08.699Z" (where Z indicates Zulu time zone, same as UTC).
-    ErrorCode:
-      title: ErrorCode
-      type: string
-      pattern: ^[1-9]\d{3}$
-      description: The API data type ErrorCode is a JSON String of four characters, consisting of digits only. Negative numbers are not allowed. A leading zero is not allowed. Each error code in the API is a four-digit number, for example, 1234, where the first number (1 in the example) represents the high-level error category, the second number (2 in the example) represents the low-level error category, and the last two numbers (34 in the example) represent the specific error.
-    ErrorDescription:
-      title: ErrorDescription
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Error description string.
-    ExtensionKey:
-      title: ExtensionKey
-      type: string
-      minLength: 1
-      maxLength: 32
-      description: Extension key.
-    ExtensionValue:
-      title: ExtensionValue
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Extension value.
-    FirstName:
-      title: FirstName
-      type: string
-      minLength: 1
-      maxLength: 128
-      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
-      description: First name of the Party (Name Type).
-    FspId:
-      title: FspId
-      type: string
-      minLength: 1
-      maxLength: 32
-      description: FSP identifier.
-    IlpCondition:
-      title: IlpCondition
-      type: string
-      pattern: ^[A-Za-z0-9-_]{43}$
-      maxLength: 48
-      description: Condition that must be attached to the transfer by the Payer.
-    IlpFulfilment:
-      title: IlpFulfilment
-      type: string
-      pattern: ^[A-Za-z0-9-_]{43}$
-      maxLength: 48
-      description: Fulfilment that must be attached to the transfer by the Payee.
-    IlpPacket:
-      title: IlpPacket
-      type: string
-      pattern: ^[A-Za-z0-9-_]+[=]{0,2}$
-      minLength: 1
-      maxLength: 32768
-      description: Information for recipient (transport layer information).
-    Integer:
-      title: Integer
-      type: string
-      pattern: ^[1-9]\d*$
-      description: The API data type Integer is a JSON String consisting of digits only. Negative numbers and leading zeroes are not allowed. The data type is always limited to a specific number of digits.
-    LastName:
-      title: LastName
-      type: string
-      minLength: 1
-      maxLength: 128
-      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
-      description: Last name of the Party (Name Type).
-    Latitude:
-      title: Latitude
-      type: string
-      pattern: ^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,6})?))$
-      description: The API data type Latitude is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
-    Longitude:
-      title: Longitude
-      type: string
-      pattern: ^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,6})?))$
-      description: The API data type Longitude is a JSON String in a lexical format that is restricted by a regular expression for interoperability reasons.
-    MerchantClassificationCode:
-      title: MerchantClassificationCode
-      type: string
-      pattern: ^[\d]{1,4}$
-      description: A limited set of pre-defined numbers. This list would be a limited set of numbers identifying a set of popular merchant types like School Fees, Pubs and Restaurants, Groceries, etc.
-    MiddleName:
-      title: MiddleName
-      type: string
-      minLength: 1
-      maxLength: 128
-      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
-      description: Middle name of the Party (Name Type).
-    Name:
-      title: Name
-      type: string
-      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
-      description:
-        The API data type Name is a JSON String, restricted by a regular expression to avoid characters which are generally not used in a name.
-
-
-        Regular Expression - The regular expression for restricting the Name type is "^(?!\s*$)[\w .,'-]{1,128}$". The restriction does not allow a string consisting of whitespace only, all Unicode characters are allowed, as well as the period (.) (apostrophe (‘), dash (-), comma (,) and space characters ( ).
-
-
-        **Note:** In some programming languages, Unicode support must be specifically enabled. For example, if Java is used, the flag UNICODE_CHARACTER_CLASS must be enabled to allow Unicode characters.
-    Note:
-      title: Note
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Memo assigned to transaction.
-    OtpValue:
-      title: OtpValue
-      type: string
-      pattern: ^\d{3,10}$
-      description: The API data type OtpValue is a JSON String of 3 to 10 characters, consisting of digits only. Negative numbers are not allowed. One or more leading zeros are allowed.
-    PartyIdentifier:
-      title: PartyIdentifier
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Identifier of the Party.
-    PartyIdType:
-      title: PartyIdType
-      type: string
-      enum:
-        - MSISDN
-        - EMAIL
-        - PERSONAL_ID
-        - BUSINESS
-        - DEVICE
-        - ACCOUNT_ID
-        - IBAN
-        - ALIAS
-      description: Below are the allowed values for the enumeration.
-
-        - MSISDN - An MSISDN (Mobile Station International Subscriber Directory Number, that is, the phone number) is used as reference to a participant. The MSISDN identifier should be in international format according to the [ITU-T E.164 standard](https://www.itu.int/rec/T-REC-E.164/en). Optionally, the MSISDN may be prefixed by a single plus sign, indicating the international prefix.
-
-        - EMAIL - An email is used as reference to a participant. The format of the email should be according to the informational [RFC 3696](https://tools.ietf.org/html/rfc3696).
-
-        - PERSONAL_ID - A personal identifier is used as reference to a participant. Examples of personal identification are passport number, birth certificate number, and national registration number. The identifier number is added in the PartyIdentifier element. The personal identifier type is added in the PartySubIdOrType element.
-
-        - BUSINESS - A specific Business (for example, an organization or a company) is used as reference to a participant. The BUSINESS identifier can be in any format. To make a transaction connected to a specific username or bill number in a Business, the PartySubIdOrType element should be used.
-
-        - DEVICE - A specific device (for example, a POS or ATM) ID connected to a specific business or organization is used as reference to a Party. For referencing a specific device under a specific business or organization, use the PartySubIdOrType element.
-
-        - ACCOUNT_ID - A bank account number or FSP account ID should be used as reference to a participant. The ACCOUNT_ID identifier can be in any format, as formats can greatly differ depending on country and FSP.
-
-        - IBAN - A bank account number or FSP account ID is used as reference to a participant. The IBAN identifier can consist of up to 34 alphanumeric characters and should be entered without whitespace.
-
-        - ALIAS An alias is used as reference to a participant. The alias should be created in the FSP as an alternative reference to an account owner. Another example of an alias is a username in the FSP system. The ALIAS identifier can be in any format. It is also possible to use the PartySubIdOrType element for identifying an account under an Alias defined by the PartyIdentifier.
-    PartyName:
-      title: PartyName
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Name of the Party. Could be a real name or a nickname.
-    PartySubIdOrType:
-      title: PartySubIdOrType
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Either a sub-identifier of a PartyIdentifier, or a sub-type of the PartyIdType, normally a PersonalIdentifierType.
-    PersonalIdentifierType:
-      title: PersonalIdentifierType
-      type: string
-      enum:
-        - PASSPORT
-        - NATIONAL_REGISTRATION
-        - DRIVING_LICENSE
-        - ALIEN_REGISTRATION
-        - NATIONAL_ID_CARD
-        - EMPLOYER_ID
-        - TAX_ID_NUMBER
-        - SENIOR_CITIZENS_CARD
-        - MARRIAGE_CERTIFICATE
-        - HEALTH_CARD
-        - VOTERS_ID
-        - UNITED_NATIONS
-        - OTHER_ID
-      description: Below are the allowed values for the enumeration.
-
-        - PASSPORT - A passport number is used as reference to a Party.
-
-        - NATIONAL_REGISTRATION - A national registration number is used as reference to a Party.
-
-        - DRIVING_LICENSE - A driving license is used as reference to a Party.
-
-        - ALIEN_REGISTRATION - An alien registration number is used as reference to a Party.
-
-        - NATIONAL_ID_CARD - A national ID card number is used as reference to a Party.
-
-        - EMPLOYER_ID - A tax identification number is used as reference to a Party.
-
-        - TAX_ID_NUMBER - A tax identification number is used as reference to a Party.
-
-        - SENIOR_CITIZENS_CARD - A senior citizens card number is used as reference to a Party.
-
-        - MARRIAGE_CERTIFICATE - A marriage certificate number is used as reference to a Party.
-
-        - HEALTH_CARD - A health card number is used as reference to a Party.
-
-        - VOTERS_ID - A voter’s identification number is used as reference to a Party.
-
-        - UNITED_NATIONS - An UN (United Nations) number is used as reference to a Party.
-
-        - OTHER_ID - Any other type of identification type number is used as reference to a Party.
-    QRCODE:
-      title: QRCODE
-      type: string
-      minLength: 1
-      maxLength: 64
-      description: QR code used as a One Time Password.
-    RefundReason:
-      title: RefundReason
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Reason for the refund.
-    TokenCode:
-      title: TokenCode
-      type: string
-      pattern: ^[0-9a-zA-Z]{4,32}$
-      description: The API data type TokenCode is a JSON String between 4 and 32 characters, consisting of digits or upper- or lowercase characters from a to z.
-    TransactionInitiator:
-      title: TransactionInitiator
-      type: string
-      enum:
-        - PAYER
-        - PAYEE
-      description: Below are the allowed values for the enumeration.
-
-        - PAYER - Sender of funds is initiating the transaction. The account to send from is either owned by the Payer or is connected to the Payer in some way.
-
-        - PAYEE - Recipient of the funds is initiating the transaction by sending a transaction request. The Payer must approve the transaction, either automatically by a pre-generated OTP or by pre-approval of the Payee, or by manually approving in his or her own Device.
-    TransactionInitiatorType:
-      title: TransactionInitiatorType
-      type: string
-      enum:
-        - CONSUMER
-        - AGENT
-        - BUSINESS
-        - DEVICE
-      description: Below are the allowed values for the enumeration.
-
-        - CONSUMER - Consumer is the initiator of the transaction.
-
-        - AGENT - Agent is the initiator of the transaction.
-
-        - BUSINESS - Business is the initiator of the transaction.
-
-        - DEVICE - Device is the initiator of the transaction.
-    TransactionRequestState:
-      title: TransactionRequestState
-      type: string
-      enum:
-        - RECEIVED
-        - PENDING
-        - ACCEPTED
-        - REJECTED
-      description: Below are the allowed values for the enumeration.
-
-        - RECEIVED - Payer FSP has received the transaction from the Payee FSP.
-
-        - PENDING - Payer FSP has sent the transaction request to the Payer.
-
-        - ACCEPTED - Payer has approved the transaction.
-
-        - REJECTED - Payer has rejected the transaction.
+      pattern: ^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$
+      description: >-
+        The API data type Amount is a JSON String in a canonical format that is
+        restricted by a regular expression for interoperability reasons. This
+        pattern does not allow any trailing zeroes at all, but allows an amount
+        without a minor currency unit. It also only allows four digits in the
+        minor currency unit; a negative value is not allowed. Using more than 18
+        digits in the major currency unit is not allowed.
+      example: '123.45'
+    Money:
+      title: Money
+      type: object
+      description: Data model for the complex type Money.
+      properties:
+        currency:
+          $ref: '#/components/schemas/Currency'
+        amount:
+          $ref: '#/components/schemas/Amount'
+      required:
+        - currency
+        - amount
     TransactionScenario:
       title: TransactionScenario
       type: string
@@ -2536,39 +2669,642 @@ components:
         - TRANSFER
         - PAYMENT
         - REFUND
-      description: Below are the allowed values for the enumeration.
+      description: >-
+        Below are the allowed values for the enumeration.
 
-        - DEPOSIT - Used for performing a Cash-In (deposit) transaction. In a normal scenario, electronic funds are transferred from a Business account to a Consumer account, and physical cash is given from the Consumer to the Business User.
+        - DEPOSIT - Used for performing a Cash-In (deposit) transaction. In a
+        normal scenario, electronic funds are transferred from a Business
+        account to a Consumer account, and physical cash is given from the
+        Consumer to the Business User.
 
-        - WITHDRAWAL - Used for performing a Cash-Out (withdrawal) transaction. In a normal scenario, electronic funds are transferred from a Consumer’s account to a Business account, and physical cash is given from the Business User to the Consumer.
+        - WITHDRAWAL - Used for performing a Cash-Out (withdrawal) transaction.
+        In a normal scenario, electronic funds are transferred from a Consumer’s
+        account to a Business account, and physical cash is given from the
+        Business User to the Consumer.
 
-        - TRANSFER - Used for performing a P2P (Peer to Peer, or Consumer to Consumer) transaction.
+        - TRANSFER - Used for performing a P2P (Peer to Peer, or Consumer to
+        Consumer) transaction.
 
-        - PAYMENT - Usually used for performing a transaction from a Consumer to a Merchant or Organization, but could also be for a B2B (Business to Business) payment. The transaction could be online for a purchase in an Internet store, in a physical store where both the Consumer and Business User are present, a bill payment, a donation, and so on.
+        - PAYMENT - Usually used for performing a transaction from a Consumer to
+        a Merchant or Organization, but could also be for a B2B (Business to
+        Business) payment. The transaction could be online for a purchase in an
+        Internet store, in a physical store where both the Consumer and Business
+        User are present, a bill payment, a donation, and so on.
 
         - REFUND - Used for performing a refund of transaction.
-    TransactionState:
-      title: TransactionState
-      type: string
-      enum:
-        - RECEIVED
-        - PENDING
-        - COMPLETED
-        - REJECTED
-      description: Below are the allowed values for the enumeration.
-
-        - RECEIVED - Payee FSP has received the transaction from the Payer FSP.
-
-        - PENDING - Payee FSP has validated the transaction.
-
-        - COMPLETED - Payee FSP has successfully performed the transaction.
-
-        - REJECTED - Payee FSP has failed to perform the transaction.
+      example: DEPOSIT
     TransactionSubScenario:
       title: TransactionSubScenario
       type: string
       pattern: ^[A-Z_]{1,32}$
-      description: Possible sub-scenario, defined locally within the scheme (UndefinedEnum Type).
+      description: >-
+        Possible sub-scenario, defined locally within the scheme (UndefinedEnum
+        Type).
+      example: LOCALLY_DEFINED_SUBSCENARIO
+    TransactionInitiator:
+      title: TransactionInitiator
+      type: string
+      enum:
+        - PAYER
+        - PAYEE
+      description: >-
+        Below are the allowed values for the enumeration.
+
+        - PAYER - Sender of funds is initiating the transaction. The account to
+        send from is either owned by the Payer or is connected to the Payer in
+        some way.
+
+        - PAYEE - Recipient of the funds is initiating the transaction by
+        sending a transaction request. The Payer must approve the transaction,
+        either automatically by a pre-generated OTP or by pre-approval of the
+        Payee, or by manually approving in his or her own Device.
+      example: PAYEE
+    TransactionInitiatorType:
+      title: TransactionInitiatorType
+      type: string
+      enum:
+        - CONSUMER
+        - AGENT
+        - BUSINESS
+        - DEVICE
+      description: |-
+        Below are the allowed values for the enumeration.
+        - CONSUMER - Consumer is the initiator of the transaction.
+        - AGENT - Agent is the initiator of the transaction.
+        - BUSINESS - Business is the initiator of the transaction.
+        - DEVICE - Device is the initiator of the transaction.
+      example: CONSUMER
+    RefundReason:
+      title: RefundReason
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Reason for the refund.
+      example: Free text indicating reason for the refund.
+    Refund:
+      title: Refund
+      type: object
+      description: Data model for the complex type Refund.
+      properties:
+        originalTransactionId:
+          $ref: '#/components/schemas/CorrelationId'
+        refundReason:
+          $ref: '#/components/schemas/RefundReason'
+      required:
+        - originalTransactionId
+    BalanceOfPayments:
+      title: BalanceOfPayments
+      type: string
+      pattern: ^[1-9]\d{2}$
+      description: >-
+        (BopCode) The API data type
+        [BopCode](https://www.imf.org/external/np/sta/bopcode/) is a JSON String
+        of 3 characters, consisting of digits only. Negative numbers are not
+        allowed. A leading zero is not allowed.
+      example: '123'
+    TransactionType:
+      title: TransactionType
+      type: object
+      description: Data model for the complex type TransactionType.
+      properties:
+        scenario:
+          $ref: '#/components/schemas/TransactionScenario'
+        subScenario:
+          $ref: '#/components/schemas/TransactionSubScenario'
+        initiator:
+          $ref: '#/components/schemas/TransactionInitiator'
+        initiatorType:
+          $ref: '#/components/schemas/TransactionInitiatorType'
+        refundInfo:
+          $ref: '#/components/schemas/Refund'
+        balanceOfPayments:
+          $ref: '#/components/schemas/BalanceOfPayments'
+      required:
+        - scenario
+        - initiator
+        - initiatorType
+    Note:
+      title: Note
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Memo assigned to transaction.
+      example: Note sent to Payee.
+    Transaction:
+      title: Transaction
+      type: object
+      description: >-
+        Data model for the complex type Transaction. The Transaction type is
+        used to carry end-to-end data between the Payer FSP and the Payee FSP in
+        the ILP Packet. Both the transactionId and the quoteId in the data model
+        are decided by the Payer FSP in the POST /quotes request.
+      properties:
+        transactionId:
+          $ref: '#/components/schemas/CorrelationId'
+        quoteId:
+          $ref: '#/components/schemas/CorrelationId'
+        payee:
+          $ref: '#/components/schemas/Party'
+        payer:
+          $ref: '#/components/schemas/Party'
+        amount:
+          $ref: '#/components/schemas/Money'
+        transactionType:
+          $ref: '#/components/schemas/TransactionType'
+        note:
+          $ref: '#/components/schemas/Note'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - transactionId
+        - quoteId
+        - payee
+        - payer
+        - amount
+        - transactionType
+    UndefinedEnum:
+      title: UndefinedEnum
+      type: string
+      pattern: ^[A-Z_]{1,32}$
+      description: >-
+        The API data type UndefinedEnum is a JSON String consisting of 1 to 32
+        uppercase characters including an underscore character (_).
+    ErrorCode:
+      title: ErrorCode
+      type: string
+      pattern: ^[1-9]\d{3}$
+      description: >-
+        The API data type ErrorCode is a JSON String of four characters,
+        consisting of digits only. Negative numbers are not allowed. A leading
+        zero is not allowed. Each error code in the API is a four-digit number,
+        for example, 1234, where the first number (1 in the example) represents
+        the high-level error category, the second number (2 in the example)
+        represents the low-level error category, and the last two numbers (34 in
+        the example) represent the specific error.
+      example: '5100'
+    ErrorDescription:
+      title: ErrorDescription
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Error description string.
+    ErrorInformation:
+      title: ErrorInformation
+      type: object
+      description: Data model for the complex type ErrorInformation.
+      properties:
+        errorCode:
+          $ref: '#/components/schemas/ErrorCode'
+        errorDescription:
+          $ref: '#/components/schemas/ErrorDescription'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - errorCode
+        - errorDescription
+    ErrorInformationResponse:
+      title: ErrorInformationResponse
+      type: object
+      description: >-
+        Data model for the complex type object that contains an optional element
+        ErrorInformation used along with 4xx and 5xx responses.
+      properties:
+        errorInformation:
+          $ref: '#/components/schemas/ErrorInformation'
+    ParticipantsTypeIDPutResponse:
+      title: ParticipantsTypeIDPutResponse
+      type: object
+      description: >-
+        The object sent in the PUT /participants/{Type}/{ID}/{SubId} and
+        /participants/{Type}/{ID} callbacks.
+      properties:
+        fspId:
+          $ref: '#/components/schemas/FspId'
+    ParticipantsTypeIDSubIDPostRequest:
+      title: ParticipantsTypeIDSubIDPostRequest
+      type: object
+      description: >-
+        The object sent in the POST /participants/{Type}/{ID}/{SubId} and
+        /participants/{Type}/{ID} requests. An additional optional ExtensionList
+        element has been added as part of v1.1 changes.
+      properties:
+        fspId:
+          $ref: '#/components/schemas/FspId'
+        currency:
+          $ref: '#/components/schemas/Currency'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - fspId
+    ErrorInformationObject:
+      title: ErrorInformationObject
+      type: object
+      description: Data model for the complex type object that contains ErrorInformation.
+      properties:
+        errorInformation:
+          $ref: '#/components/schemas/ErrorInformation'
+      required:
+        - errorInformation
+    ParticipantsPostRequest:
+      title: ParticipantsPostRequest
+      type: object
+      description: The object sent in the POST /participants request.
+      properties:
+        requestId:
+          $ref: '#/components/schemas/CorrelationId'
+        partyList:
+          type: array
+          items:
+            $ref: '#/components/schemas/PartyIdInfo'
+          minItems: 1
+          maxItems: 10000
+          description: >-
+            List of PartyIdInfo elements that the client would like to update or
+            create FSP information about.
+        currency:
+          $ref: '#/components/schemas/Currency'
+      required:
+        - requestId
+        - partyList
+    PartyResult:
+      title: PartyResult
+      type: object
+      description: Data model for the complex type PartyResult.
+      properties:
+        partyId:
+          $ref: '#/components/schemas/PartyIdInfo'
+        errorInformation:
+          $ref: '#/components/schemas/ErrorInformation'
+      required:
+        - partyId
+    ParticipantsIDPutResponse:
+      title: ParticipantsIDPutResponse
+      type: object
+      description: The object sent in the PUT /participants/{ID} callback.
+      properties:
+        partyList:
+          type: array
+          items:
+            $ref: '#/components/schemas/PartyResult'
+          minItems: 1
+          maxItems: 10000
+          description: >-
+            List of PartyResult elements that were either created or failed to
+            be created.
+        currency:
+          $ref: '#/components/schemas/Currency'
+      required:
+        - partyList
+    PartiesTypeIDPutResponse:
+      title: PartiesTypeIDPutResponse
+      type: object
+      description: The object sent in the PUT /parties/{Type}/{ID} callback.
+      properties:
+        party:
+          $ref: '#/components/schemas/Party'
+      required:
+        - party
+    Latitude:
+      title: Latitude
+      type: string
+      pattern: >-
+        ^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,6})?))$
+      description: >-
+        The API data type Latitude is a JSON String in a lexical format that is
+        restricted by a regular expression for interoperability reasons.
+      example: '+45.4215'
+    Longitude:
+      title: Longitude
+      type: string
+      pattern: >-
+        ^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,6})?))$
+      description: >-
+        The API data type Longitude is a JSON String in a lexical format that is
+        restricted by a regular expression for interoperability reasons.
+      example: '+75.6972'
+    GeoCode:
+      title: GeoCode
+      type: object
+      description: >-
+        Data model for the complex type GeoCode. Indicates the geographic
+        location from where the transaction was initiated.
+      properties:
+        latitude:
+          $ref: '#/components/schemas/Latitude'
+        longitude:
+          $ref: '#/components/schemas/Longitude'
+      required:
+        - latitude
+        - longitude
+    AuthenticationType:
+      title: AuthenticationType
+      type: string
+      enum:
+        - OTP
+        - QRCODE
+        - U2F
+      description: |-
+        Below are the allowed values for the enumeration AuthenticationType.
+        - OTP - One-time password generated by the Payer FSP.
+        - QRCODE - QR code used as One Time Password.
+        - U2F - U2F is a new addition isolated to Thirdparty stream.
+      example: OTP
+    DateTime:
+      title: DateTime
+      type: string
+      pattern: >-
+        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$
+      description: >-
+        The API data type DateTime is a JSON String in a lexical format that is
+        restricted by a regular expression for interoperability reasons. The
+        format is according to [ISO
+        8601](https://www.iso.org/iso-8601-date-and-time-format.html), expressed
+        in a combined date, time and time zone format. A more readable version
+        of the format is yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]. Examples are
+        "2016-05-24T08:38:08.699-04:00", "2016-05-24T08:38:08.699Z" (where Z
+        indicates Zulu time zone, same as UTC).
+      example: '2016-05-24T08:38:08.699-04:00'
+    TransactionRequestsPostRequest:
+      title: TransactionRequestsPostRequest
+      type: object
+      description: The object sent in the POST /transactionRequests request.
+      properties:
+        transactionRequestId:
+          $ref: '#/components/schemas/CorrelationId'
+        payee:
+          $ref: '#/components/schemas/Party'
+        payer:
+          $ref: '#/components/schemas/PartyIdInfo'
+        amount:
+          $ref: '#/components/schemas/Money'
+        transactionType:
+          $ref: '#/components/schemas/TransactionType'
+        note:
+          $ref: '#/components/schemas/Note'
+        geoCode:
+          $ref: '#/components/schemas/GeoCode'
+        authenticationType:
+          $ref: '#/components/schemas/AuthenticationType'
+        expiration:
+          $ref: '#/components/schemas/DateTime'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - transactionRequestId
+        - payee
+        - payer
+        - amount
+        - transactionType
+    TransactionRequestState:
+      title: TransactionRequestState
+      type: string
+      enum:
+        - RECEIVED
+        - PENDING
+        - ACCEPTED
+        - REJECTED
+      description: |-
+        Below are the allowed values for the enumeration.
+        - RECEIVED - Payer FSP has received the transaction from the Payee FSP.
+        - PENDING - Payer FSP has sent the transaction request to the Payer.
+        - ACCEPTED - Payer has approved the transaction.
+        - REJECTED - Payer has rejected the transaction.
+      example: RECEIVED
+    TransactionRequestsIDPutResponse:
+      title: TransactionRequestsIDPutResponse
+      type: object
+      description: The object sent in the PUT /transactionRequests/{ID} callback.
+      properties:
+        transactionId:
+          $ref: '#/components/schemas/CorrelationId'
+        transactionRequestState:
+          $ref: '#/components/schemas/TransactionRequestState'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - transactionRequestState
+    AmountType:
+      title: AmountType
+      type: string
+      enum:
+        - SEND
+        - RECEIVE
+      description: >-
+        Below are the allowed values for the enumeration AmountType.
+
+        - SEND - Amount the Payer would like to send, that is, the amount that
+        should be withdrawn from the Payer account including any fees.
+
+        - RECEIVE - Amount the Payer would like the Payee to receive, that is,
+        the amount that should be sent to the receiver exclusive of any fees.
+      example: RECEIVE
+    QuotesPostRequest:
+      title: QuotesPostRequest
+      type: object
+      description: The object sent in the POST /quotes request.
+      properties:
+        quoteId:
+          $ref: '#/components/schemas/CorrelationId'
+        transactionId:
+          $ref: '#/components/schemas/CorrelationId'
+        transactionRequestId:
+          $ref: '#/components/schemas/CorrelationId'
+        payee:
+          $ref: '#/components/schemas/Party'
+        payer:
+          $ref: '#/components/schemas/Party'
+        amountType:
+          $ref: '#/components/schemas/AmountType'
+        amount:
+          $ref: '#/components/schemas/Money'
+        fees:
+          $ref: '#/components/schemas/Money'
+        transactionType:
+          $ref: '#/components/schemas/TransactionType'
+        geoCode:
+          $ref: '#/components/schemas/GeoCode'
+        note:
+          $ref: '#/components/schemas/Note'
+        expiration:
+          $ref: '#/components/schemas/DateTime'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - quoteId
+        - transactionId
+        - payee
+        - payer
+        - amountType
+        - amount
+        - transactionType
+    IlpPacket:
+      title: IlpPacket
+      type: string
+      pattern: ^[A-Za-z0-9-_]+[=]{0,2}$
+      minLength: 1
+      maxLength: 32768
+      description: Information for recipient (transport layer information).
+      example: >-
+        AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
+    IlpCondition:
+      title: IlpCondition
+      type: string
+      pattern: ^[A-Za-z0-9-_]{43}$
+      maxLength: 48
+      description: Condition that must be attached to the transfer by the Payer.
+    QuotesIDPutResponse:
+      title: QuotesIDPutResponse
+      type: object
+      description: The object sent in the PUT /quotes/{ID} callback.
+      properties:
+        transferAmount:
+          $ref: '#/components/schemas/Money'
+        payeeReceiveAmount:
+          $ref: '#/components/schemas/Money'
+        payeeFspFee:
+          $ref: '#/components/schemas/Money'
+        payeeFspCommission:
+          $ref: '#/components/schemas/Money'
+        expiration:
+          $ref: '#/components/schemas/DateTime'
+        geoCode:
+          $ref: '#/components/schemas/GeoCode'
+        ilpPacket:
+          $ref: '#/components/schemas/IlpPacket'
+        condition:
+          $ref: '#/components/schemas/IlpCondition'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - transferAmount
+        - expiration
+        - ilpPacket
+        - condition
+    OtpValue:
+      title: OtpValue
+      type: string
+      pattern: ^\d{3,10}$
+      description: >-
+        The API data type OtpValue is a JSON String of 3 to 10 characters,
+        consisting of digits only. Negative numbers are not allowed. One or more
+        leading zeros are allowed.
+    QRCODE:
+      title: QRCODE
+      type: string
+      minLength: 1
+      maxLength: 64
+      description: QR code used as a One Time Password.
+    U2FPIN:
+      title: U2FPIN
+      type: string
+      pattern: ^\S{1,64}$
+      minLength: 1
+      maxLength: 64
+      description: >
+        U2F challenge-response, where payer FSP verifies if the response
+        provided by end-user device matches the previously registered key.
+    U2FPinValue:
+      title: U2FPinValue
+      type: object
+      description: >
+        U2F challenge-response, where payer FSP verifies if the response
+        provided by end-user device matches the previously registered key.
+      properties:
+        pinValue:
+          allOf:
+            - $ref: '#/components/schemas/U2FPIN'
+          description: U2F challenge-response.
+        counter:
+          allOf:
+            - $ref: '#/components/schemas/Integer'
+          description: >-
+            Sequential counter used for cloning detection. Present only for U2F
+            authentication.
+      required:
+        - pinValue
+        - counter
+    AuthenticationValue:
+      title: AuthenticationValue
+      anyOf:
+        - $ref: '#/components/schemas/OtpValue'
+        - $ref: '#/components/schemas/QRCODE'
+        - $ref: '#/components/schemas/U2FPinValue'
+      pattern: ^\d{3,10}$|^\S{1,64}$
+      description: >-
+        Contains the authentication value. The format depends on the
+        authentication type used in the AuthenticationInfo complex type.
+    AuthenticationInfo:
+      title: AuthenticationInfo
+      type: object
+      description: Data model for the complex type AuthenticationInfo.
+      properties:
+        authentication:
+          $ref: '#/components/schemas/AuthenticationType'
+        authenticationValue:
+          $ref: '#/components/schemas/AuthenticationValue'
+      required:
+        - authentication
+        - authenticationValue
+    AuthorizationResponse:
+      title: AuthorizationResponse
+      type: string
+      enum:
+        - ENTERED
+        - REJECTED
+        - RESEND
+      description: |-
+        Below are the allowed values for the enumeration.
+        - ENTERED - Consumer entered the authentication value.
+        - REJECTED - Consumer rejected the transaction.
+        - RESEND - Consumer requested to resend the authentication value.
+      example: ENTERED
+    AuthorizationsIDPutResponse:
+      title: AuthorizationsIDPutResponse
+      type: object
+      description: The object sent in the PUT /authorizations/{ID} callback.
+      properties:
+        authenticationInfo:
+          $ref: '#/components/schemas/AuthenticationInfo'
+        responseType:
+          $ref: '#/components/schemas/AuthorizationResponse'
+      required:
+        - responseType
+    TransfersPostRequest:
+      title: TransfersPostRequest
+      type: object
+      description: The object sent in the POST /transfers request.
+      properties:
+        transferId:
+          $ref: '#/components/schemas/CorrelationId'
+        payeeFsp:
+          $ref: '#/components/schemas/FspId'
+        payerFsp:
+          $ref: '#/components/schemas/FspId'
+        amount:
+          $ref: '#/components/schemas/Money'
+        ilpPacket:
+          $ref: '#/components/schemas/IlpPacket'
+        condition:
+          $ref: '#/components/schemas/IlpCondition'
+        expiration:
+          $ref: '#/components/schemas/DateTime'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - transferId
+        - payeeFsp
+        - payerFsp
+        - amount
+        - ilpPacket
+        - condition
+        - expiration
+    IlpFulfilment:
+      title: IlpFulfilment
+      type: string
+      pattern: ^[A-Za-z0-9-_]{43}$
+      maxLength: 48
+      description: Fulfilment that must be attached to the transfer by the Payee.
+      example: WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8
     TransferState:
       title: TransferState
       type: string
@@ -2577,7 +3313,8 @@ components:
         - RESERVED
         - COMMITTED
         - ABORTED
-      description: Below are the allowed values for the enumeration.
+      description: >-
+        Below are the allowed values for the enumeration.
 
         - RECEIVED - Next ledger has received the transfer.
 
@@ -2585,45 +3322,157 @@ components:
 
         - COMMITTED - Next ledger has successfully performed the transfer.
 
-        - ABORTED - Next ledger has aborted the transfer due to a rejection or failure to perform the transfer.
-    UndefinedEnum:
-      title: UndefinedEnum
+        - ABORTED - Next ledger has aborted the transfer due to a rejection or
+        failure to perform the transfer.
+      example: RESERVED
+    TransfersIDPutResponse:
+      title: TransfersIDPutResponse
+      type: object
+      description: The object sent in the PUT /transfers/{ID} callback.
+      properties:
+        fulfilment:
+          $ref: '#/components/schemas/IlpFulfilment'
+        completedTimestamp:
+          $ref: '#/components/schemas/DateTime'
+        transferState:
+          $ref: '#/components/schemas/TransferState'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - transferState
+    TransfersIDPatchResponse:
+      title: TransfersIDPatchResponse
+      type: object
+      description: PATCH /transfers/{ID} object
+      properties:
+        completedTimestamp:
+          $ref: '#/components/schemas/DateTime'
+        transferState:
+          $ref: '#/components/schemas/TransferState'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - completedTimestamp
+        - transferState
+    TransactionState:
+      title: TransactionState
       type: string
-      pattern: ^[A-Z_]{1,32}$
-      description: The API data type UndefinedEnum is a JSON String consisting of 1 to 32 uppercase characters including an underscore character (_).
-
-    #Complex Types
-    AuthenticationInfo:
-      title: AuthenticationInfo
+      enum:
+        - RECEIVED
+        - PENDING
+        - COMPLETED
+        - REJECTED
+      description: |-
+        Below are the allowed values for the enumeration.
+        - RECEIVED - Payee FSP has received the transaction from the Payer FSP.
+        - PENDING - Payee FSP has validated the transaction.
+        - COMPLETED - Payee FSP has successfully performed the transaction.
+        - REJECTED - Payee FSP has failed to perform the transaction.
+      example: RECEIVED
+    Code:
+      title: Code
+      type: string
+      pattern: ^[0-9a-zA-Z]{4,32}$
+      description: Any code/token returned by the Payee FSP (TokenCode Type).
+      example: Test-Code
+    TransactionsIDPutResponse:
+      title: TransactionsIDPutResponse
       type: object
-      description: Data model for the complex type AuthenticationInfo.
+      description: The object sent in the PUT /transactions/{ID} callback.
       properties:
-        authentication:
-          $ref: "#/components/schemas/AuthenticationType"
-          description: Type of authentication.
-          example: OTP
-        authenticationValue:
-          $ref: "#/components/schemas/AuthenticationValue"
-          description: Authentication value.
-          example: 1234
+        completedTimestamp:
+          $ref: '#/components/schemas/DateTime'
+        transactionState:
+          $ref: '#/components/schemas/TransactionState'
+        code:
+          $ref: '#/components/schemas/Code'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
       required:
-        - authentication
-        - authenticationValue
-    AuthorizationsIDPutResponse:
-      title: AuthorizationsIDPutResponse
+        - transactionState
+    IndividualQuote:
+      title: IndividualQuote
       type: object
-      description: The object sent in the PUT /authorizations/{ID} callback.
+      description: Data model for the complex type IndividualQuote.
       properties:
-        authenticationInfo:
-          $ref: "#/components/schemas/AuthenticationInfo"
-          description: OTP or QR Code if entered, otherwise empty.
-          example: OTP
-        responseType:
-          $ref: "#/components/schemas/AuthorizationResponse"
-          description: Enum containing response information; if the customer entered the authentication value, rejected the transaction, or requested a resend of the authentication value.
-          example: ENTERED
+        quoteId:
+          $ref: '#/components/schemas/CorrelationId'
+        transactionId:
+          $ref: '#/components/schemas/CorrelationId'
+        payee:
+          $ref: '#/components/schemas/Party'
+        amountType:
+          $ref: '#/components/schemas/AmountType'
+        amount:
+          $ref: '#/components/schemas/Money'
+        fees:
+          $ref: '#/components/schemas/Money'
+        transactionType:
+          $ref: '#/components/schemas/TransactionType'
+        note:
+          $ref: '#/components/schemas/Note'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
       required:
-        - responseType
+        - quoteId
+        - transactionId
+        - payee
+        - amountType
+        - amount
+        - transactionType
+    BulkQuotesPostRequest:
+      title: BulkQuotesPostRequest
+      type: object
+      description: The object sent in the POST /bulkQuotes request.
+      properties:
+        bulkQuoteId:
+          $ref: '#/components/schemas/CorrelationId'
+        payer:
+          $ref: '#/components/schemas/Party'
+        geoCode:
+          $ref: '#/components/schemas/GeoCode'
+        expiration:
+          $ref: '#/components/schemas/DateTime'
+        individualQuotes:
+          type: array
+          minItems: 1
+          maxItems: 1000
+          items:
+            $ref: '#/components/schemas/IndividualQuote'
+          description: List of quotes elements.
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - bulkQuoteId
+        - payer
+        - individualQuotes
+    IndividualQuoteResult:
+      title: IndividualQuoteResult
+      type: object
+      description: Data model for the complex type IndividualQuoteResult.
+      properties:
+        quoteId:
+          $ref: '#/components/schemas/CorrelationId'
+        payee:
+          $ref: '#/components/schemas/Party'
+        transferAmount:
+          $ref: '#/components/schemas/Money'
+        payeeReceiveAmount:
+          $ref: '#/components/schemas/Money'
+        payeeFspFee:
+          $ref: '#/components/schemas/Money'
+        payeeFspCommission:
+          $ref: '#/components/schemas/Money'
+        ilpPacket:
+          $ref: '#/components/schemas/IlpPacket'
+        condition:
+          $ref: '#/components/schemas/IlpCondition'
+        errorInformation:
+          $ref: '#/components/schemas/ErrorInformation'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - quoteId
     BulkQuotesIDPutResponse:
       title: BulkQuotesIDPutResponse
       type: object
@@ -2633,109 +3482,60 @@ components:
           type: array
           maxItems: 1000
           items:
-            $ref: "#/components/schemas/IndividualQuoteResult"
-          description: Fees for each individual transaction, if any of them are charged per transaction.
+            $ref: '#/components/schemas/IndividualQuoteResult'
+          description: >-
+            Fees for each individual transaction, if any of them are charged per
+            transaction.
         expiration:
-          $ref: "#/components/schemas/DateTime"
-          description: Date and time until when the quotation is valid and can be honored when used in the subsequent transaction request.
-          example: "2016-05-24T08:38:08.699-04:00"
+          $ref: '#/components/schemas/DateTime'
         extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
+          $ref: '#/components/schemas/ExtensionList'
       required:
         - expiration
-    BulkQuotesPostRequest:
-      title: BulkQuotesPostRequest
+    IndividualTransfer:
+      title: IndividualTransfer
       type: object
-      description: The object sent in the POST /bulkQuotes request.
+      description: Data model for the complex type IndividualTransfer.
       properties:
-        bulkQuoteId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Common ID between the FSPs for the bulk quote object, decided by the Payer FSP. The ID should be reused for resends of the same bulk quote. A new ID should be generated for each new bulk quote.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
-        payer:
-          $ref: "#/components/schemas/Party"
-          description: Information about the Payer in the proposed financial transaction.
-        geoCode:
-          $ref: "#/components/schemas/GeoCode"
-          description: Longitude and Latitude of the initiating Party. Can be used to detect fraud.
-        expiration:
-          $ref: "#/components/schemas/DateTime"
-          description: Expiration is optional to let the Payee FSP know when a quote no longer needs to be returned.
-          example: "2016-05-24T08:38:08.699-04:00"
-        individualQuotes:
-          type: array
-          minItems: 1
-          maxItems: 1000
-          items:
-            $ref: "#/components/schemas/IndividualQuote"
-          description: List of quotes elements.
+        transferId:
+          $ref: '#/components/schemas/CorrelationId'
+        transferAmount:
+          $ref: '#/components/schemas/Money'
+        ilpPacket:
+          $ref: '#/components/schemas/IlpPacket'
+        condition:
+          $ref: '#/components/schemas/IlpCondition'
         extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
+          $ref: '#/components/schemas/ExtensionList'
       required:
-        - bulkQuoteId
-        - payer
-        - individualQuotes
-    BulkTransfersIDPutResponse:
-      title: BulkTransfersIDPutResponse
-      type: object
-      description: The object sent in the PUT /bulkTransfers/{ID} callback.
-      properties:
-        completedTimestamp:
-          $ref: "#/components/schemas/DateTime"
-          description: Time and date when the bulk transaction was completed.
-          example: "2016-05-24T08:38:08.699-04:00"
-        individualTransferResults:
-          type: array
-          maxItems: 1000
-          items:
-            $ref: "#/components/schemas/IndividualTransferResult"
-          description: List of IndividualTransferResult elements.
-        bulkTransferState:
-          $ref: "#/components/schemas/BulkTransferState"
-          description: The state of the bulk transfer.
-          example: RECEIVED
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - bulkTransferState
+        - transferId
+        - transferAmount
+        - ilpPacket
+        - condition
     BulkTransfersPostRequest:
       title: BulkTransfersPostRequest
       type: object
       description: The object sent in the POST /bulkTransfers request.
       properties:
         bulkTransferId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Common ID between the FSPs and the optional Switch for the bulk transfer object, decided by the Payer FSP. The ID should be reused for resends of the same bulk transfer. A new ID should be generated for each new bulk transfer.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+          $ref: '#/components/schemas/CorrelationId'
         bulkQuoteId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: ID of the related bulk quote.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+          $ref: '#/components/schemas/CorrelationId'
         payerFsp:
-          $ref: "#/components/schemas/FspId"
-          description: Payer FSP identifier.
-          example: 5678
+          $ref: '#/components/schemas/FspId'
         payeeFsp:
-          $ref: "#/components/schemas/FspId"
-          description: Payee FSP identifier.
-          example: 1234
+          $ref: '#/components/schemas/FspId'
         individualTransfers:
           type: array
           minItems: 1
           maxItems: 1000
           items:
-            $ref: "#/components/schemas/IndividualTransfer"
+            $ref: '#/components/schemas/IndividualTransfer'
           description: List of IndividualTransfer elements.
         expiration:
-          $ref: "#/components/schemas/DateTime"
-          description: Expiration time of the transfers.
-          example: "2016-05-24T08:38:08.699-04:00"
+          $ref: '#/components/schemas/DateTime'
         extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
+          $ref: '#/components/schemas/ExtensionList'
       required:
         - bulkTransferId
         - bulkQuoteId
@@ -2743,882 +3543,90 @@ components:
         - payeeFsp
         - individualTransfers
         - expiration
-    ErrorInformation:
-      title: ErrorInformation
-      type: object
-      description: Data model for the complex type ErrorInformation.
-      properties:
-        errorCode:
-          $ref: "#/components/schemas/ErrorCode"
-          description: Specific error number.
-          example: 5100
-        errorDescription:
-          $ref: "#/components/schemas/ErrorDescription"
-          description: Error description string.
-          example: This is an error description.
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-      required:
-        - errorCode
-        - errorDescription
-    ErrorInformationObject:
-      title: ErrorInformationObject
-      type: object
-      description: Data model for the complex type object that contains ErrorInformation.
-      properties:
-        errorInformation:
-          $ref: "#/components/schemas/ErrorInformation"
-      required:
-        - errorInformation
-    ErrorInformationResponse:
-      title: ErrorInformationResponse
-      type: object
-      description: Data model for the complex type object that contains an optional element ErrorInformation used along with 4xx and 5xx responses.
-      properties:
-        errorInformation:
-          $ref: "#/components/schemas/ErrorInformation"
-    Extension:
-      title: Extension
-      type: object
-      description: Data model for the complex type Extension.
-      properties:
-        key:
-          $ref: "#/components/schemas/ExtensionKey"
-          description: Extension key.
-        value:
-          $ref: "#/components/schemas/ExtensionValue"
-          description: Extension value.
-      required:
-        - key
-        - value
-    ExtensionList:
-      title: ExtensionList
-      type: object
-      description: Data model for the complex type ExtensionList. An optional list of extensions, specific to deployment.
-      properties:
-        extension:
-          type: array
-          items:
-            $ref: "#/components/schemas/Extension"
-          minItems: 1
-          maxItems: 16
-          description: Number of Extension elements.
-      required:
-        - extension
-    GeoCode:
-      title: GeoCode
-      type: object
-      description: Data model for the complex type GeoCode. Indicates the geographic location from where the transaction was initiated.
-      properties:
-        latitude:
-          $ref: "#/components/schemas/Latitude"
-          description: Latitude of the Party.
-          example: "+45.4215"
-        longitude:
-          $ref: "#/components/schemas/Longitude"
-          description: Longitude of the Party.
-          example: "+75.6972"
-      required:
-        - latitude
-        - longitude
-    IndividualQuote:
-      title: IndividualQuote
-      type: object
-      description: Data model for the complex type IndividualQuote.
-      properties:
-        quoteId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Identifies the quote message.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
-        transactionId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Identifies the transaction message.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
-        payee:
-          $ref: "#/components/schemas/Party"
-          description: Information about the Payee in the proposed financial transaction.
-        amountType:
-          $ref: "#/components/schemas/AmountType"
-          description: SEND for sendAmount, RECEIVE for receiveAmount.
-          example: RECEIVE
-        amount:
-          $ref: "#/components/schemas/Money"
-          description: Depending on amountType
-            If SEND - The amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees. The amount is updated by each participating entity in the transaction.
-            If RECEIVE - The amount the Payee should receive, that is, the amount that should be sent to the receiver exclusive of any fees. The amount is not updated by any of the participating entities.
-        fees:
-          $ref: "#/components/schemas/Money"
-          description: The fees in the transaction.
-            The fees element should be empty if fees should be non-disclosed.
-            The fees element should be non-empty if fees should be disclosed.
-        transactionType:
-          $ref: "#/components/schemas/TransactionType"
-          description: Type of transaction that the quote is requested for.
-        note:
-          $ref: "#/components/schemas/Note"
-          description: Memo that will be attached to the transaction.
-          example: Note sent to Payee.
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - quoteId
-        - transactionId
-        - payee
-        - amountType
-        - amount
-        - transactionType
-    IndividualQuoteResult:
-      title: IndividualQuoteResult
-      type: object
-      description: Data model for the complex type IndividualQuoteResult.
-      properties:
-        quoteId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Identifies the quote message.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
-        payee:
-          $ref: "#/components/schemas/Party"
-          description: Information about the Payee in the proposed financial transaction.
-        transferAmount:
-          $ref: "#/components/schemas/Money"
-          description: The amount of money that the Payee FSP should receive.
-        payeeReceiveAmount:
-          $ref: "#/components/schemas/Money"
-          description: The amount of Money that the Payee should receive in the end-to-end transaction. Optional as the Payee FSP might not want to disclose any optional Payee fees.
-        payeeFspFee:
-          $ref: "#/components/schemas/Money"
-          description: Payee FSP’s part of the transaction fee.
-        payeeFspCommission:
-          $ref: "#/components/schemas/Money"
-          description: Transaction commission from the Payee FSP.
-        ilpPacket:
-          $ref: "#/components/schemas/IlpPacket"
-          description: The ILP Packet that must be attached to the transfer by the Payer.
-          example: AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
-        condition:
-          $ref: "#/components/schemas/IlpCondition"
-          description: The condition that must be attached to the transfer by the Payer.
-          example: f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA
-        errorInformation:
-          $ref: "#/components/schemas/ErrorInformation"
-          description: Error code, category description. **Note:** receiveAmount, payeeFspFee, payeeFspCommission, expiration, ilpPacket, condition should not be set if errorInformation is set.
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - quoteId
-    IndividualTransfer:
-      title: IndividualTransfer
-      type: object
-      description: Data model for the complex type IndividualTransfer.
-      properties:
-        transferId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Identifies messages related to the same /transfers sequence.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
-        transferAmount:
-          $ref: "#/components/schemas/Money"
-          description: Transaction amount to be sent.
-        ilpPacket:
-          $ref: "#/components/schemas/IlpPacket"
-          description: ILP Packet containing the amount delivered to the Payee and the ILP Address of the Payee and any other end-to-end data.
-          example: AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
-        condition:
-          $ref: "#/components/schemas/IlpCondition"
-          description: Condition that must be fulfilled to commit the transfer.
-          example: f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - transferId
-        - transferAmount
-        - ilpPacket
-        - condition
     IndividualTransferResult:
       title: IndividualTransferResult
       type: object
       description: Data model for the complex type IndividualTransferResult.
       properties:
         transferId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Identifies messages related to the same /transfers sequence.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
+          $ref: '#/components/schemas/CorrelationId'
         fulfilment:
-          $ref: "#/components/schemas/IlpFulfilment"
-          description: Fulfilment of the condition specified with the transaction. **Note:** Either fulfilment or errorInformation should be set, not both.
-          example: WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8
+          $ref: '#/components/schemas/IlpFulfilment'
         errorInformation:
-          $ref: "#/components/schemas/ErrorInformation"
-          description: If transfer is REJECTED, error information may be provided. **Note:** Either fulfilment or errorInformation should be set, not both.
+          $ref: '#/components/schemas/ErrorInformation'
         extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
+          $ref: '#/components/schemas/ExtensionList'
       required:
         - transferId
-    Money:
-      title: Money
-      type: object
-      description: Data model for the complex type Money.
-      properties:
-        currency:
-          $ref: "#/components/schemas/Currency"
-          description: Currency of the amount.
-          example: USD
-        amount:
-          $ref: "#/components/schemas/Amount"
-          description: Amount of Money.
-          example: "123.45"
-      required:
-        - currency
-        - amount
-    ParticipantsIDPutResponse:
-      title: ParticipantsIDPutResponse
-      type: object
-      description: The object sent in the PUT /participants/{ID} callback.
-      properties:
-        partyList:
-          type: array
-          items:
-            $ref: "#/components/schemas/PartyResult"
-          minItems: 1
-          maxItems: 10000
-          description: List of PartyResult elements that were either created or failed to be created.
-        currency:
-          $ref: "#/components/schemas/Currency"
-          description: Indicate that the provided Currency was set to be supported by each successfully added PartyIdInfo.
-          example: USD
-      required:
-        - partyList
-    ParticipantsPostRequest:
-      title: ParticipantsPostRequest
-      type: object
-      description: The object sent in the POST /participants request.
-      properties:
-        requestId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: The ID of the request, decided by the client. Used for identification of the callback from the server.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
-        partyList:
-          type: array
-          items:
-            $ref: "#/components/schemas/PartyIdInfo"
-          minItems: 1
-          maxItems: 10000
-          description: List of PartyIdInfo elements that the client would like to update or create FSP information about.
-        currency:
-          $ref: "#/components/schemas/Currency"
-          description: Indicate that the provided Currency is supported by each PartyIdInfo in the list.
-          example: USD
-      required:
-        - requestId
-        - partyList
-    ParticipantsTypeIDPutResponse:
-      title: ParticipantsTypeIDPutResponse
-      type: object
-      description: The object sent in the PUT /participants/{Type}/{ID}/{SubId} and /participants/{Type}/{ID} callbacks.
-      properties:
-        fspId:
-          $ref: "#/components/schemas/FspId"
-          description: FSP Identifier that the Party belongs to.
-          example: 1234
-    ParticipantsTypeIDSubIDPostRequest:
-      title: ParticipantsTypeIDSubIDPostRequest
-      type: object
-      description: The object sent in the POST /participants/{Type}/{ID}/{SubId} and /participants/{Type}/{ID} requests. An additional optional ExtensionList element has been added as part of v1.1 changes.
-      properties:
-        fspId:
-          $ref: "#/components/schemas/FspId"
-          description: FSP Identifier that the Party belongs to.
-          example: 1234
-        currency:
-          $ref: "#/components/schemas/Currency"
-          description: Indicate that the provided Currency is supported by the Party.
-          example: USD
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - fspId
-    PartiesTypeIDPutResponse:
-      title: PartiesTypeIDPutResponse
-      type: object
-      description: The object sent in the PUT /parties/{Type}/{ID} callback.
-      properties:
-        party:
-          $ref: "#/components/schemas/Party"
-          description: Information regarding the requested Party.
-      required:
-        - party
-    Party:
-      title: Party
-      type: object
-      description: Data model for the complex type Party.
-      properties:
-        partyIdInfo:
-          $ref: "#/components/schemas/PartyIdInfo"
-          description: Party Id type, id, sub ID or type, and FSP Id.
-        merchantClassificationCode:
-          $ref: "#/components/schemas/MerchantClassificationCode"
-          description: Used in the context of Payee Information, where the Payee happens to be a merchant accepting merchant payments.
-          example: 4321
-        name:
-          $ref: "#/components/schemas/PartyName"
-          description: Display name of the Party, could be a real name or a nick name.
-          example: Henrik Karlsson
-        personalInfo:
-          $ref: "#/components/schemas/PartyPersonalInfo"
-          description: Personal information used to verify identity of Party such as first, middle, last name and date of birth.
-      required:
-        - partyIdInfo
-    PartyComplexName:
-      title: PartyComplexName
-      type: object
-      description: Data model for the complex type PartyComplexName.
-      properties:
-        firstName:
-          $ref: "#/components/schemas/FirstName"
-          description: Party’s first name.
-          example: Henrik
-        middleName:
-          $ref: "#/components/schemas/MiddleName"
-          description: Party’s middle name.
-          example: Johannes
-        lastName:
-          $ref: "#/components/schemas/LastName"
-          description: Party’s last name.
-          example: Karlsson
-    PartyIdInfo:
-      title: PartyIdInfo
-      type: object
-      description: Data model for the complex type PartyIdInfo. An ExtensionList element has been added to this reqeust in version v1.1
-      properties:
-        partyIdType:
-          $ref: "#/components/schemas/PartyIdType"
-          description: Type of the identifier.
-          example: PERSONAL_ID
-        partyIdentifier:
-          $ref: "#/components/schemas/PartyIdentifier"
-          description: An identifier for the Party.
-          example: 16135551212
-        partySubIdOrType:
-          $ref: "#/components/schemas/PartySubIdOrType"
-          description: A sub-identifier or sub-type for the Party.
-          example: DRIVING_LICENSE
-        fspId:
-          $ref: "#/components/schemas/FspId"
-          description: FSP ID (if known).
-          example: 1234
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - partyIdType
-        - partyIdentifier
-    PartyPersonalInfo:
-      title: PartyPersonalInfo
-      type: object
-      description: Data model for the complex type PartyPersonalInfo.
-      properties:
-        complexName:
-          $ref: "#/components/schemas/PartyComplexName"
-          description: First, middle and last name for the Party.
-        dateOfBirth:
-          $ref: "#/components/schemas/DateOfBirth"
-          description: Date of birth for the Party.
-          example: "1966-06-16"
-    PartyResult:
-      title: PartyResult
-      type: object
-      description: Data model for the complex type PartyResult.
-      properties:
-        partyId:
-          $ref: "#/components/schemas/PartyIdInfo"
-          description: Party Id type, id, sub ID or type, and FSP Id.
-        errorInformation:
-          $ref: "#/components/schemas/ErrorInformation"
-          description: If the Party failed to be added, error information should be provided. Otherwise, this parameter should be empty to indicate success.
-      required:
-        - partyId
-    QuotesIDPutResponse:
-      title: QuotesIDPutResponse
-      type: object
-      description: The object sent in the PUT /quotes/{ID} callback.
-      properties:
-        transferAmount:
-          $ref: "#/components/schemas/Money"
-          description: The amount of money that the Payee FSP should receive.
-        payeeReceiveAmount:
-          $ref: "#/components/schemas/Money"
-          description: The amount of Money that the Payee should receive in the end-to-end transaction. Optional as the Payee FSP might not want to disclose any optional Payee fees.
-        payeeFspFee:
-          $ref: "#/components/schemas/Money"
-          description: Payee FSP’s part of the transaction fee.
-        payeeFspCommission:
-          $ref: "#/components/schemas/Money"
-          description: Transaction commission from the Payee FSP.
-        expiration:
-          $ref: "#/components/schemas/DateTime"
-          description: Date and time until when the quotation is valid and can be honored when used in the subsequent transaction.
-          example: "2016-05-24T08:38:08.699-04:00"
-        geoCode:
-          $ref: "#/components/schemas/GeoCode"
-          description: Longitude and Latitude of the Payee. Can be used to detect fraud.
-        ilpPacket:
-          $ref: "#/components/schemas/IlpPacket"
-          description: The ILP Packet that must be attached to the transfer by the Payer.
-          example: “AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA”
-        condition:
-          $ref: "#/components/schemas/IlpCondition"
-          description: The condition that must be attached to the transfer by the Payer.
-          example: f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - transferAmount
-        - expiration
-        - ilpPacket
-        - condition
-    QuotesPostRequest:
-      title: QuotesPostRequest
-      type: object
-      description: The object sent in the POST /quotes request.
-      properties:
-        quoteId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Common ID between the FSPs for the quote object, decided by the Payer FSP. The ID should be reused for resends of the same quote for a transaction. A new ID should be generated for each new quote for a transaction.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
-        transactionId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Common ID (decided by the Payer FSP) between the FSPs for the future transaction object. The actual transaction will be created as part of a successful transfer process. The ID should be reused for resends of the same quote for a transaction. A new ID should be generated for each new quote for a transaction.
-          example: a8323bc6-c228-4df2-ae82-e5a997baf899
-        transactionRequestId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Identifies an optional previously-sent transaction request.
-          example: a8323bc6-c228-4df2-ae82-e5a997baf890
-        payee:
-          $ref: "#/components/schemas/Party"
-          description: Information about the Payee in the proposed financial transaction.
-        payer:
-          $ref: "#/components/schemas/Party"
-          description: Information about the Payer in the proposed financial transaction.
-        amountType:
-          $ref: "#/components/schemas/AmountType"
-          description: SEND for send amount, RECEIVE for receive amount.
-          example: SEND
-        amount:
-          $ref: "#/components/schemas/Money"
-          description: Depending on amountType -
-            If SEND - The amount the Payer would like to send, that is, the amount that should be withdrawn from the Payer account including any fees. The amount is updated by each participating entity in the transaction.
-            If RECEIVE - The amount the Payee should receive, that is, the amount that should be sent to the receiver exclusive any fees. The amount is not updated by any of the participating entities.
-        fees:
-          $ref: "#/components/schemas/Money"
-          description: The fees in the transaction.
-            The fees element should be empty if fees should be non-disclosed.
-            The fees element should be non-empty if fees should be disclosed.
-        transactionType:
-          $ref: "#/components/schemas/TransactionType"
-          description: Type of transaction for which the quote is requested.
-        geoCode:
-          $ref: "#/components/schemas/GeoCode"
-          description: Longitude and Latitude of the initiating Party. Can be used to detect fraud.
-        note:
-          $ref: "#/components/schemas/Note"
-          description: A memo that will be attached to the transaction.
-          example: Free-text memo.
-        expiration:
-          $ref: "#/components/schemas/DateTime"
-          description: Expiration is optional. It can be set to get a quick failure in case the peer FSP takes too long to respond. Also, it may be beneficial for Consumer, Agent, and Merchant to know that their request has a time limit.
-          example: "2016-05-24T08:38:08.699-04:00"
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - quoteId
-        - transactionId
-        - payee
-        - payer
-        - amountType
-        - amount
-        - transactionType
-    Refund:
-      title: Refund
-      type: object
-      description: Data model for the complex type Refund.
-      properties:
-        originalTransactionId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Reference to the original transaction ID that is requested to be refunded.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
-        refundReason:
-          $ref: "#/components/schemas/RefundReason"
-          description: Free text indicating the reason for the refund.
-          example: Free text indicating reason for the refund.
-      required:
-        - originalTransactionId
-    Transaction:
-      title: Transaction
-      type: object
-      description: Data model for the complex type Transaction. The Transaction type is used to carry end-to-end data between the Payer FSP and the Payee FSP in the ILP Packet. Both the transactionId and the quoteId in the data model are decided by the Payer FSP in the POST /quotes request.
-      properties:
-        transactionId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: ID of the transaction, the ID is decided by the Payer FSP during the creation of the quote.
-        quoteId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: ID of the quote, the ID is decided by the Payer FSP during the creation of the quote.
-        payee:
-          $ref: "#/components/schemas/Party"
-          description: Information about the Payee in the proposed financial transaction.
-        payer:
-          $ref: "#/components/schemas/Party"
-          description: Information about the Payer in the proposed financial transaction.
-        amount:
-          $ref: "#/components/schemas/Money"
-          description: Transaction amount to be sent.
-        transactionType:
-          $ref: "#/components/schemas/TransactionType"
-          description: Type of the transaction.
-        note:
-          $ref: "#/components/schemas/Note"
-          description: Memo associated to the transaction, intended to the Payee.
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - transactionId
-        - quoteId
-        - payee
-        - payer
-        - amount
-        - transactionType
-    TransactionRequestsIDPutResponse:
-      title: TransactionRequestsIDPutResponse
-      type: object
-      description: The object sent in the PUT /transactionRequests/{ID} callback.
-      properties:
-        transactionId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Identifies a related transaction (if a transaction has been created).
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
-        transactionRequestState:
-          $ref: "#/components/schemas/TransactionRequestState"
-          description: State of the transaction request.
-          example: RECEIVED
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - transactionRequestState
-    TransactionRequestsPostRequest:
-      title: TransactionRequestsPostRequest
-      type: object
-      description: The object sent in the POST /transactionRequests request.
-      properties:
-        transactionRequestId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: Common ID between the FSPs for the transaction request object, decided by the Payee FSP. The ID should be reused for resends of the same transaction request. A new ID should be generated for each new transaction request.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
-        payee:
-          $ref: "#/components/schemas/Party"
-          description: Information about the Payee in the proposed financial transaction.
-        payer:
-          $ref: "#/components/schemas/PartyIdInfo"
-          description: Information about the Payer type, id, sub-type/id, FSP Id in the proposed financial transaction.
-        amount:
-          $ref: "#/components/schemas/Money"
-          description: Requested amount to be transferred from the Payer to Payee.
-        transactionType:
-          $ref: "#/components/schemas/TransactionType"
-          description: Type of transaction.
-        note:
-          $ref: "#/components/schemas/Note"
-          description: Reason for the transaction request, intended to the Payer.
-          example: Free-text memo.
-        geoCode:
-          $ref: "#/components/schemas/GeoCode"
-          description: Longitude and Latitude of the initiating Party. Can be used to detect fraud.
-        authenticationType:
-          $ref: "#/components/schemas/AuthenticationType"
-          description: OTP or QR Code, otherwise empty.
-          example: OTP
-        expiration:
-          $ref: "#/components/schemas/DateTime"
-          description: Can be set to get a quick failure in case the peer FSP takes too long to respond. Also, it may be beneficial for Consumer, Agent, Merchant to know that their request has a time limit.
-          example: "2016-05-24T08:38:08.699-04:00"
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - transactionRequestId
-        - payee
-        - payer
-        - amount
-        - transactionType
-    TransactionsIDPutResponse:
-      title: TransactionsIDPutResponse
-      type: object
-      description: The object sent in the PUT /transactions/{ID} callback.
-      properties:
-        completedTimestamp:
-          $ref: "#/components/schemas/DateTime"
-          description: Time and date when the transaction was completed.
-          example: "2016-05-24T08:38:08.699-04:00"
-        transactionState:
-          $ref: "#/components/schemas/TransactionState"
-          description: State of the transaction.
-          example: RECEIVED
-        code:
-          $ref: "#/components/schemas/Code"
-          description: Optional redemption information provided to Payer after transaction has been completed.
-          example: Test-Code
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - transactionState
-    TransactionType:
-      title: TransactionType
-      type: object
-      description: Data model for the complex type TransactionType.
-      properties:
-        scenario:
-          $ref: "#/components/schemas/TransactionScenario"
-          description: Deposit, withdrawal, refund, …
-          example: DEPOSIT
-        subScenario:
-          $ref: "#/components/schemas/TransactionSubScenario"
-          description: Possible sub-scenario, defined locally within the scheme.
-          example: Locally defined sub-scenario.
-        initiator:
-          $ref: "#/components/schemas/TransactionInitiator"
-          description: Who is initiating the transaction - Payer or Payee.
-          example: PAYEE
-        initiatorType:
-          $ref: "#/components/schemas/TransactionInitiatorType"
-          description: Consumer, agent, business, …
-          example: CONSUMER
-        refundInfo:
-          $ref: "#/components/schemas/Refund"
-          description: Extra information specific to a refund scenario. Should only be populated if scenario is REFUND.
-        balanceOfPayments:
-          $ref: "#/components/schemas/BalanceOfPayments"
-          description: Balance of Payments code.
-          example: 123
-      required:
-        - scenario
-        - initiator
-        - initiatorType
-    TransfersIDPatchResponse:
-      title: TransfersIDPatchResponse
-      type: object
-      description: PATCH /transfers/{ID} object
-      properties:
-        completedTimestamp:
-          $ref: "#/components/schemas/DateTime"
-          description: Time and date when the transaction was completed.
-          example: "2020-05-19T08:38:08.699-04:00"
-        transferState:
-          $ref: "#/components/schemas/TransferState"
-          description: State of the transfer.
-          example: RESERVED
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - completedTimestamp
-        - transferState
-    TransfersIDPutResponse:
-      title: TransfersIDPutResponse
-      type: object
-      description: The object sent in the PUT /transfers/{ID} callback.
-      properties:
-        fulfilment:
-          $ref: "#/components/schemas/IlpFulfilment"
-          description: Fulfilment of the condition specified with the transaction. Mandatory if transfer has completed successfully.
-          example: WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8
-        completedTimestamp:
-          $ref: "#/components/schemas/DateTime"
-          description: Time and date when the transaction was completed.
-          example: "2016-05-24T08:38:08.699-04:00"
-        transferState:
-          $ref: "#/components/schemas/TransferState"
-          description: State of the transfer.
-          example: COMMITTED
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - transferState
-    TransfersPostRequest:
-      title: TransfersPostRequest
-      type: object
-      description: The object sent in the POST /transfers request.
-      properties:
-        transferId:
-          $ref: "#/components/schemas/CorrelationId"
-          description: The common ID between the FSPs and the optional Switch for the transfer object, decided by the Payer FSP. The ID should be reused for resends of the same transfer. A new ID should be generated for each new transfer.
-          example: b51ec534-ee48-4575-b6a9-ead2955b8069
-        payeeFsp:
-          $ref: "#/components/schemas/FspId"
-          description: Payee FSP in the proposed financial transaction.
-          example: 1234
-        payerFsp:
-          $ref: "#/components/schemas/FspId"
-          description: Payer FSP in the proposed financial transaction.
-          example: 5678
-        amount:
-          $ref: "#/components/schemas/Money"
-          description: The transfer amount to be sent.
-        ilpPacket:
-          $ref: "#/components/schemas/IlpPacket"
-          description: The ILP Packet containing the amount delivered to the Payee and the ILP Address of the Payee and any other end-to-end data.
-          example: AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
-        condition:
-          $ref: "#/components/schemas/IlpCondition"
-          description: The condition that must be fulfilled to commit the transfer.
-          example: f5sqb7tBTWPd5Y8BDFdMm9BJR_MNI4isf8p8n4D5pHA
-        expiration:
-          $ref: "#/components/schemas/DateTime"
-          description: Expiration can be set to get a quick failure expiration of the transfer. The transfer should be rolled back if no fulfilment is delivered before this time.
-          example: "2016-05-24T08:38:08.699-04:00"
-        extensionList:
-          $ref: "#/components/schemas/ExtensionList"
-          description: Optional extension, specific to deployment.
-      required:
-        - transferId
-        - payeeFsp
-        - payerFsp
-        - amount
-        - ilpPacket
-        - condition
-        - expiration
+    BulkTransferState:
+      title: BulkTransactionState
+      type: string
+      enum:
+        - RECEIVED
+        - PENDING
+        - ACCEPTED
+        - PROCESSING
+        - COMPLETED
+        - REJECTED
+      description: >-
+        Below are the allowed values for the enumeration.
 
-  responses:
-    "200":
-      description: OK
-    "202":
-      description: Accepted
-    "400":
-      description: Bad Request
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInformationResponse"
-      headers:
-        Content-Length:
-          description: Content-Length header
-          $ref: "#/components/parameters/Content-Length"
-        Content-Type:
-          description: Content-Length header
-          $ref: "#/components/parameters/Content-Type"
-    "401":
-      description: Unauthorized
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInformationResponse"
-      headers:
-        Content-Length:
-          $ref: "#/components/parameters/Content-Length"
-        Content-Type:
-          $ref: "#/components/parameters/Content-Type"
-    "403":
-      description: Forbidden
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInformationResponse"
-      headers:
-        Content-Length:
-          $ref: "#/components/parameters/Content-Length"
-        Content-Type:
-          $ref: "#/components/parameters/Content-Type"
-    "404":
-      description: Not Found
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInformationResponse"
-      headers:
-        Content-Length:
-          $ref: "#/components/parameters/Content-Length"
-        Content-Type:
-          $ref: "#/components/parameters/Content-Type"
-    "405":
-      description: Method Not Allowed
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInformationResponse"
-      headers:
-        Content-Length:
-          $ref: "#/components/parameters/Content-Length"
-        Content-Type:
-          $ref: "#/components/parameters/Content-Type"
-    "406":
-      description: Not Acceptable
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInformationResponse"
-      headers:
-        Content-Length:
-          $ref: "#/components/parameters/Content-Length"
-        Content-Type:
-          $ref: "#/components/parameters/Content-Type"
-    "501":
-      description: Not Implemented
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInformationResponse"
-      headers:
-        Content-Length:
-          $ref: "#/components/parameters/Content-Length"
-        Content-Type:
-          $ref: "#/components/parameters/Content-Type"
-    "503":
-      description: Service Unavailable
-      content:
-        application/json:
-          schema:
-            $ref: "#/components/schemas/ErrorInformationResponse"
-      headers:
-        Content-Length:
-          $ref: "#/components/parameters/Content-Length"
-        Content-Type:
-          $ref: "#/components/parameters/Content-Type"
+        - RECEIVED - Payee FSP has received the bulk transfer from the Payer
+        FSP.
 
+        - PENDING - Payee FSP has validated the bulk transfer.
+
+        - ACCEPTED - Payee FSP has accepted to process the bulk transfer.
+
+        - PROCESSING - Payee FSP has started to transfer fund to the Payees.
+
+        - COMPLETED - Payee FSP has completed transfer of funds to the Payees.
+
+        - REJECTED - Payee FSP has rejected to process the bulk transfer.
+      example: RECEIVED
+    BulkTransfersIDPutResponse:
+      title: BulkTransfersIDPutResponse
+      type: object
+      description: The object sent in the PUT /bulkTransfers/{ID} callback.
+      properties:
+        completedTimestamp:
+          $ref: '#/components/schemas/DateTime'
+        individualTransferResults:
+          type: array
+          maxItems: 1000
+          items:
+            $ref: '#/components/schemas/IndividualTransferResult'
+          description: List of IndividualTransferResult elements.
+        bulkTransferState:
+          $ref: '#/components/schemas/BulkTransferState'
+        extensionList:
+          $ref: '#/components/schemas/ExtensionList'
+      required:
+        - bulkTransferState
   parameters:
-    #Header parameters
-    Accept:
-      name: Accept
-      in: header
+    Type:
+      name: Type
+      in: path
       required: true
       schema:
         type: string
-      description: The `Accept` header field indicates the version of the API the client would like the server to use.
-    Content-Length:
-      name: Content-Length
-      in: header
-      required: false
+      description: The type of the party identifier. For example, `MSISDN`, `PERSONAL_ID`.
+    ID:
+      name: ID
+      in: path
+      required: true
       schema:
-        type: integer
-      description:
-        The `Content-Length` header field indicates the anticipated size of the payload body. Only sent if there is a body.
-
-
-        **Note:** The API supports a maximum size of 5242880 bytes (5 Megabytes).
+        type: string
+      description: The identifier value.
     Content-Type:
       name: Content-Type
       in: header
       schema:
         type: string
       required: true
-      description: The `Content-Type` header indicates the specific version of the API used to send the payload body.
+      description: >-
+        The `Content-Type` header indicates the specific version of the API used
+        to send the payload body.
     Date:
       name: Date
       in: header
@@ -3632,72 +3640,225 @@ components:
       schema:
         type: string
       required: false
-      description:
-        The `X-Forwarded-For` header field is an unofficially accepted standard used for informational purposes of the originating client IP address, as a request might pass multiple proxies, firewalls, and so on. Multiple `X-Forwarded-For` values should be expected and supported by implementers of the API.
+      description: >-
+        The `X-Forwarded-For` header field is an unofficially accepted standard
+        used for informational purposes of the originating client IP address, as
+        a request might pass multiple proxies, firewalls, and so on. Multiple
+        `X-Forwarded-For` values should be expected and supported by
+        implementers of the API.
 
 
-        **Note:** An alternative to `X-Forwarded-For` is defined in [RFC 7239](https://tools.ietf.org/html/rfc7239). However, to this point RFC 7239 is less-used and supported than `X-Forwarded-For`.
+        **Note:** An alternative to `X-Forwarded-For` is defined in [RFC
+        7239](https://tools.ietf.org/html/rfc7239). However, to this point RFC
+        7239 is less-used and supported than `X-Forwarded-For`.
     FSPIOP-Source:
       name: FSPIOP-Source
       in: header
       schema:
         type: string
       required: true
-      description: The `FSPIOP-Source` header field is a non-HTTP standard field used by the API for identifying the sender of the HTTP request. The field should be set by the original sender of the request. Required for routing and signature verification (see header field `FSPIOP-Signature`).
+      description: >-
+        The `FSPIOP-Source` header field is a non-HTTP standard field used by
+        the API for identifying the sender of the HTTP request. The field should
+        be set by the original sender of the request. Required for routing and
+        signature verification (see header field `FSPIOP-Signature`).
     FSPIOP-Destination:
       name: FSPIOP-Destination
       in: header
       schema:
         type: string
       required: false
-      description: The `FSPIOP-Destination` header field is a non-HTTP standard field used by the API for HTTP header based routing of requests and responses to the destination. The field must be set by the original sender of the request if the destination is known (valid for all services except GET /parties) so that any entities between the client and the server do not need to parse the payload for routing purposes. If the destination is not known (valid for service GET /parties), the field should be left empty.
+      description: >-
+        The `FSPIOP-Destination` header field is a non-HTTP standard field used
+        by the API for HTTP header based routing of requests and responses to
+        the destination. The field must be set by the original sender of the
+        request if the destination is known (valid for all services except GET
+        /parties) so that any entities between the client and the server do not
+        need to parse the payload for routing purposes. If the destination is
+        not known (valid for service GET /parties), the field should be left
+        empty.
     FSPIOP-Encryption:
       name: FSPIOP-Encryption
       in: header
       schema:
         type: string
       required: false
-      description: The `FSPIOP-Encryption` header field is a non-HTTP standard field used by the API for applying end-to-end encryption of the request.
+      description: >-
+        The `FSPIOP-Encryption` header field is a non-HTTP standard field used
+        by the API for applying end-to-end encryption of the request.
     FSPIOP-Signature:
       name: FSPIOP-Signature
       in: header
       schema:
         type: string
       required: false
-      description: The `FSPIOP-Signature` header field is a non-HTTP standard field used by the API for applying an end-to-end request signature.
+      description: >-
+        The `FSPIOP-Signature` header field is a non-HTTP standard field used by
+        the API for applying an end-to-end request signature.
     FSPIOP-URI:
       name: FSPIOP-URI
       in: header
       schema:
         type: string
       required: false
-      description: The `FSPIOP-URI` header field is a non-HTTP standard field used by the API for signature verification, should contain the service URI. Required if signature verification is used, for more information, see [the API Signature document](https://github.com/mojaloop/docs/tree/master/Specification%20Document%20Set).
+      description: >-
+        The `FSPIOP-URI` header field is a non-HTTP standard field used by the
+        API for signature verification, should contain the service URI. Required
+        if signature verification is used, for more information, see [the API
+        Signature
+        document](https://github.com/mojaloop/docs/tree/main/Specification%20Document%20Set).
     FSPIOP-HTTP-Method:
       name: FSPIOP-HTTP-Method
       in: header
       schema:
         type: string
       required: false
-      description: The `FSPIOP-HTTP-Method` header field is a non-HTTP standard field used by the API for signature verification, should contain the service HTTP method. Required if signature verification is used, for more information, see [the API Signature document](https://github.com/mojaloop/docs/tree/master/Specification%20Document%20Set).
-    #Path parameters
-    ID:
-      name: ID
-      in: path
+      description: >-
+        The `FSPIOP-HTTP-Method` header field is a non-HTTP standard field used
+        by the API for signature verification, should contain the service HTTP
+        method. Required if signature verification is used, for more
+        information, see [the API Signature
+        document](https://github.com/mojaloop/docs/tree/main/Specification%20Document%20Set).
+    Accept:
+      name: Accept
+      in: header
       required: true
       schema:
         type: string
-      description: The identifier value.
-    Type:
-      name: Type
-      in: path
-      required: true
+      description: >-
+        The `Accept` header field indicates the version of the API the client
+        would like the server to use.
+    Content-Length:
+      name: Content-Length
+      in: header
+      required: false
       schema:
-        type: string
-      description: The type of the party identifier. For example, `MSISDN`, `PERSONAL_ID`.
+        type: integer
+      description: >-
+        The `Content-Length` header field indicates the anticipated size of the
+        payload body. Only sent if there is a body.
+
+
+        **Note:** The API supports a maximum size of 5242880 bytes (5
+        Megabytes).
     SubId:
       name: SubId
       in: path
       required: true
       schema:
         type: string
-      description: A sub-identifier of the party identifier, or a sub-type of the party identifier's type. For example, `PASSPORT`, `DRIVING_LICENSE`.
+      description: >-
+        A sub-identifier of the party identifier, or a sub-type of the party
+        identifier's type. For example, `PASSPORT`, `DRIVING_LICENSE`.
+  responses:
+    '200':
+      description: OK
+    '202':
+      description: Accepted
+    '400':
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/headers/Content-Length'
+        Content-Type:
+          $ref: '#/components/headers/Content-Type'
+    '401':
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/headers/Content-Length'
+        Content-Type:
+          $ref: '#/components/headers/Content-Type'
+    '403':
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/headers/Content-Length'
+        Content-Type:
+          $ref: '#/components/headers/Content-Type'
+    '404':
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/headers/Content-Length'
+        Content-Type:
+          $ref: '#/components/headers/Content-Type'
+    '405':
+      description: Method Not Allowed
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/headers/Content-Length'
+        Content-Type:
+          $ref: '#/components/headers/Content-Type'
+    '406':
+      description: Not Acceptable
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/headers/Content-Length'
+        Content-Type:
+          $ref: '#/components/headers/Content-Type'
+    '501':
+      description: Not Implemented
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/headers/Content-Length'
+        Content-Type:
+          $ref: '#/components/headers/Content-Type'
+    '503':
+      description: Service Unavailable
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorInformationResponse'
+      headers:
+        Content-Length:
+          $ref: '#/components/headers/Content-Length'
+        Content-Type:
+          $ref: '#/components/headers/Content-Type'
+  headers:
+    Content-Length:
+      required: false
+      schema:
+        type: integer
+      description: >-
+        The `Content-Length` header field indicates the anticipated size of the
+        payload body. Only sent if there is a body.
+
+
+        **Note:** The API supports a maximum size of 5242880 bytes (5
+        Megabytes).
+    Content-Type:
+      schema:
+        type: string
+      required: true
+      description: >-
+        The `Content-Type` header indicates the specific version of the API used
+        to send the payload body.

--- a/fspiop-api/documents/v1.1-document-set/fspiop-v1.1-openapi3.yaml
+++ b/fspiop-api/documents/v1.1-document-set/fspiop-v1.1-openapi3.yaml
@@ -1,17 +1,17 @@
 openapi: 3.0.2
 info:
-  version: '1.1'
+  version: "1.1"
   title: Open API for FSP Interoperability (FSPIOP)
   description: >-
     Based on [API Definition updated on 2020-05-19 Version
-    1.1](https://github.com/mojaloop/mojaloop-specification/blob/master/documents/v1.1-document-set/API%20Definition_v1.1.pdf).
+    1.1](https://github.com/mojaloop/mojaloop-specification/blob/main/documents/v1.1-document-set/API%20Definition_v1.1.pdf).
 
 
     **Note:** The API supports a maximum size of 65536 bytes (64 Kilobytes) in
     the HTTP header.
   license:
     name: CC BY-ND 4.0
-    url: https://github.com/mojaloop/mojaloop-specification/blob/master/LICENSE.md
+    url: https://github.com/mojaloop/mojaloop-specification/blob/main/LICENSE.md
   contact:
     name: Sam Kummary
     url: https://github.com/mojaloop/mojaloop-specification/issues
@@ -24,19 +24,43 @@ servers:
           - https
         default: https
 paths:
+  /interface:
+    post:
+      description: >-
+        Essential path to include schema definitions that are not used so that
+        these definitions get included into the openapi-cli bundle api
+        definition so that they get converted into typescript definitions.
+      operationId: test
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: "#/components/schemas/BinaryString"
+                - $ref: "#/components/schemas/BinaryString32"
+                - $ref: "#/components/schemas/Date"
+                - $ref: "#/components/schemas/Integer"
+                - $ref: "#/components/schemas/Name"
+                - $ref: "#/components/schemas/PersonalIdentifierType"
+                - $ref: "#/components/schemas/TokenCode"
+                - $ref: "#/components/schemas/Transaction"
+                - $ref: "#/components/schemas/UndefinedEnum"
+      responses:
+        "200":
+          description: Ok
   /participants/{Type}/{ID}:
     parameters:
-      - $ref: '#/components/parameters/Type'
-      - $ref: '#/components/parameters/ID'
-      - $ref: '#/components/parameters/Content-Type'
-      - $ref: '#/components/parameters/Date'
-      - $ref: '#/components/parameters/X-Forwarded-For'
-      - $ref: '#/components/parameters/FSPIOP-Source'
-      - $ref: '#/components/parameters/FSPIOP-Destination'
-      - $ref: '#/components/parameters/FSPIOP-Encryption'
-      - $ref: '#/components/parameters/FSPIOP-Signature'
-      - $ref: '#/components/parameters/FSPIOP-URI'
-      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      - $ref: "#/components/parameters/Type"
+      - $ref: "#/components/parameters/ID"
+      - $ref: "#/components/parameters/Content-Type"
+      - $ref: "#/components/parameters/Date"
+      - $ref: "#/components/parameters/X-Forwarded-For"
+      - $ref: "#/components/parameters/FSPIOP-Source"
+      - $ref: "#/components/parameters/FSPIOP-Destination"
+      - $ref: "#/components/parameters/FSPIOP-Encryption"
+      - $ref: "#/components/parameters/FSPIOP-Signature"
+      - $ref: "#/components/parameters/FSPIOP-URI"
+      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     post:
       description: >-
         The HTTP request `POST /participants/{Type}/{ID}` (or `POST
@@ -50,34 +74,34 @@ paths:
         - participants
       operationId: ParticipantsByIDAndType
       parameters:
-        - $ref: '#/components/parameters/Accept'
-        - $ref: '#/components/parameters/Content-Length'
+        - $ref: "#/components/parameters/Accept"
+        - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Participant information to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ParticipantsTypeIDSubIDPostRequest'
+              $ref: "#/components/schemas/ParticipantsTypeIDSubIDPostRequest"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     get:
       description: >-
         The HTTP request `GET /participants/{Type}/{ID}` (or `GET
@@ -93,26 +117,26 @@ paths:
         - participants
       operationId: ParticipantsByTypeAndID
       parameters:
-        - $ref: '#/components/parameters/Accept'
+        - $ref: "#/components/parameters/Accept"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     put:
       description: >-
         The callback `PUT /participants/{Type}/{ID}` (or `PUT
@@ -126,33 +150,33 @@ paths:
         - participants
       operationId: ParticipantsByTypeAndID3
       parameters:
-        - $ref: '#/components/parameters/Content-Length'
+        - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Participant information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ParticipantsTypeIDPutResponse'
+              $ref: "#/components/schemas/ParticipantsTypeIDPutResponse"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     delete:
       description: >-
         The HTTP request `DELETE /participants/{Type}/{ID}` (or `DELETE
@@ -173,26 +197,26 @@ paths:
         - participants
       operationId: ParticipantsByTypeAndID2
       parameters:
-        - $ref: '#/components/parameters/Accept'
+        - $ref: "#/components/parameters/Accept"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /participants/{Type}/{ID}/error:
     put:
       description: >-
@@ -205,58 +229,58 @@ paths:
         - participants
       operationId: ParticipantsErrorByTypeAndID
       parameters:
-        - $ref: '#/components/parameters/Type'
-        - $ref: '#/components/parameters/ID'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/Type"
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ErrorInformationObject'
+              $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /participants/{Type}/{ID}/{SubId}:
     parameters:
-      - $ref: '#/components/parameters/Type'
-      - $ref: '#/components/parameters/ID'
-      - $ref: '#/components/parameters/SubId'
-      - $ref: '#/components/parameters/Content-Type'
-      - $ref: '#/components/parameters/Date'
-      - $ref: '#/components/parameters/X-Forwarded-For'
-      - $ref: '#/components/parameters/FSPIOP-Source'
-      - $ref: '#/components/parameters/FSPIOP-Destination'
-      - $ref: '#/components/parameters/FSPIOP-Encryption'
-      - $ref: '#/components/parameters/FSPIOP-Signature'
-      - $ref: '#/components/parameters/FSPIOP-URI'
-      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      - $ref: "#/components/parameters/Type"
+      - $ref: "#/components/parameters/ID"
+      - $ref: "#/components/parameters/SubId"
+      - $ref: "#/components/parameters/Content-Type"
+      - $ref: "#/components/parameters/Date"
+      - $ref: "#/components/parameters/X-Forwarded-For"
+      - $ref: "#/components/parameters/FSPIOP-Source"
+      - $ref: "#/components/parameters/FSPIOP-Destination"
+      - $ref: "#/components/parameters/FSPIOP-Encryption"
+      - $ref: "#/components/parameters/FSPIOP-Signature"
+      - $ref: "#/components/parameters/FSPIOP-URI"
+      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     post:
       description: >-
         The HTTP request `POST /participants/{Type}/{ID}` (or `POST
@@ -270,34 +294,34 @@ paths:
         - participants
       operationId: ParticipantsSubIdByTypeAndIDPost
       parameters:
-        - $ref: '#/components/parameters/Accept'
-        - $ref: '#/components/parameters/Content-Length'
+        - $ref: "#/components/parameters/Accept"
+        - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Participant information to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ParticipantsTypeIDSubIDPostRequest'
+              $ref: "#/components/schemas/ParticipantsTypeIDSubIDPostRequest"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     get:
       description: >-
         The HTTP request `GET /participants/{Type}/{ID}` (or `GET
@@ -313,26 +337,26 @@ paths:
         - participants
       operationId: ParticipantsSubIdByTypeAndID
       parameters:
-        - $ref: '#/components/parameters/Accept'
+        - $ref: "#/components/parameters/Accept"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     put:
       description: >-
         The callback `PUT /participants/{Type}/{ID}` (or `PUT
@@ -346,33 +370,33 @@ paths:
         - participants
       operationId: ParticipantsSubIdByTypeAndID3
       parameters:
-        - $ref: '#/components/parameters/Content-Length'
+        - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Participant information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ParticipantsTypeIDPutResponse'
+              $ref: "#/components/schemas/ParticipantsTypeIDPutResponse"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     delete:
       description: >-
         The HTTP request `DELETE /participants/{Type}/{ID}` (or `DELETE
@@ -393,26 +417,26 @@ paths:
         - participants
       operationId: ParticipantsSubIdByTypeAndID2
       parameters:
-        - $ref: '#/components/parameters/Accept'
+        - $ref: "#/components/parameters/Accept"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /participants/{Type}/{ID}/{SubId}/error:
     put:
       description: >-
@@ -425,45 +449,45 @@ paths:
         - participants
       operationId: ParticipantsSubIdErrorByTypeAndID
       parameters:
-        - $ref: '#/components/parameters/Type'
-        - $ref: '#/components/parameters/ID'
-        - $ref: '#/components/parameters/SubId'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/Type"
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/SubId"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ErrorInformationObject'
+              $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /participants:
     post:
       description: >-
@@ -477,43 +501,43 @@ paths:
         - participants
       operationId: Participants1
       parameters:
-        - $ref: '#/components/parameters/Accept'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/Accept"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Participant information to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ParticipantsPostRequest'
+              $ref: "#/components/schemas/ParticipantsPostRequest"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /participants/{ID}:
     put:
       description: >-
@@ -524,43 +548,43 @@ paths:
         - participants
       operationId: putParticipantsByID
       parameters:
-        - $ref: '#/components/parameters/ID'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Participant information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ParticipantsIDPutResponse'
+              $ref: "#/components/schemas/ParticipantsIDPutResponse"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /participants/{ID}/error:
     put:
       description: >-
@@ -573,56 +597,56 @@ paths:
         - participants
       operationId: ParticipantsByIDAndError
       parameters:
-        - $ref: '#/components/parameters/ID'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ErrorInformationObject'
+              $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /parties/{Type}/{ID}:
     parameters:
-      - $ref: '#/components/parameters/Type'
-      - $ref: '#/components/parameters/ID'
-      - $ref: '#/components/parameters/Content-Type'
-      - $ref: '#/components/parameters/Date'
-      - $ref: '#/components/parameters/X-Forwarded-For'
-      - $ref: '#/components/parameters/FSPIOP-Source'
-      - $ref: '#/components/parameters/FSPIOP-Destination'
-      - $ref: '#/components/parameters/FSPIOP-Encryption'
-      - $ref: '#/components/parameters/FSPIOP-Signature'
-      - $ref: '#/components/parameters/FSPIOP-URI'
-      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      - $ref: "#/components/parameters/Type"
+      - $ref: "#/components/parameters/ID"
+      - $ref: "#/components/parameters/Content-Type"
+      - $ref: "#/components/parameters/Date"
+      - $ref: "#/components/parameters/X-Forwarded-For"
+      - $ref: "#/components/parameters/FSPIOP-Source"
+      - $ref: "#/components/parameters/FSPIOP-Destination"
+      - $ref: "#/components/parameters/FSPIOP-Encryption"
+      - $ref: "#/components/parameters/FSPIOP-Signature"
+      - $ref: "#/components/parameters/FSPIOP-URI"
+      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
       description: >-
         The HTTP request `GET /parties/{Type}/{ID}` (or `GET
@@ -635,26 +659,26 @@ paths:
         - parties
       operationId: PartiesByTypeAndID
       parameters:
-        - $ref: '#/components/parameters/Accept'
+        - $ref: "#/components/parameters/Accept"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     put:
       description: >-
         The callback `PUT /parties/{Type}/{ID}` (or `PUT
@@ -665,33 +689,33 @@ paths:
         - parties
       operationId: PartiesByTypeAndID2
       parameters:
-        - $ref: '#/components/parameters/Content-Length'
+        - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Party information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PartiesTypeIDPutResponse'
+              $ref: "#/components/schemas/PartiesTypeIDPutResponse"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /parties/{Type}/{ID}/error:
     put:
       description: >-
@@ -704,58 +728,58 @@ paths:
         - parties
       operationId: PartiesErrorByTypeAndID
       parameters:
-        - $ref: '#/components/parameters/Type'
-        - $ref: '#/components/parameters/ID'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/Type"
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ErrorInformationObject'
+              $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /parties/{Type}/{ID}/{SubId}:
     parameters:
-      - $ref: '#/components/parameters/Type'
-      - $ref: '#/components/parameters/ID'
-      - $ref: '#/components/parameters/SubId'
-      - $ref: '#/components/parameters/Content-Type'
-      - $ref: '#/components/parameters/Date'
-      - $ref: '#/components/parameters/X-Forwarded-For'
-      - $ref: '#/components/parameters/FSPIOP-Source'
-      - $ref: '#/components/parameters/FSPIOP-Destination'
-      - $ref: '#/components/parameters/FSPIOP-Encryption'
-      - $ref: '#/components/parameters/FSPIOP-Signature'
-      - $ref: '#/components/parameters/FSPIOP-URI'
-      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      - $ref: "#/components/parameters/Type"
+      - $ref: "#/components/parameters/ID"
+      - $ref: "#/components/parameters/SubId"
+      - $ref: "#/components/parameters/Content-Type"
+      - $ref: "#/components/parameters/Date"
+      - $ref: "#/components/parameters/X-Forwarded-For"
+      - $ref: "#/components/parameters/FSPIOP-Source"
+      - $ref: "#/components/parameters/FSPIOP-Destination"
+      - $ref: "#/components/parameters/FSPIOP-Encryption"
+      - $ref: "#/components/parameters/FSPIOP-Signature"
+      - $ref: "#/components/parameters/FSPIOP-URI"
+      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
       description: >-
         The HTTP request `GET /parties/{Type}/{ID}` (or `GET
@@ -768,26 +792,26 @@ paths:
         - parties
       operationId: PartiesSubIdByTypeAndID
       parameters:
-        - $ref: '#/components/parameters/Accept'
+        - $ref: "#/components/parameters/Accept"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     put:
       description: >-
         The callback `PUT /parties/{Type}/{ID}` (or `PUT
@@ -798,33 +822,33 @@ paths:
         - parties
       operationId: PartiesSubIdByTypeAndIDPut
       parameters:
-        - $ref: '#/components/parameters/Content-Length'
+        - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Party information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PartiesTypeIDPutResponse'
+              $ref: "#/components/schemas/PartiesTypeIDPutResponse"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /parties/{Type}/{ID}/{SubId}/error:
     put:
       description: >-
@@ -837,45 +861,45 @@ paths:
         - parties
       operationId: PartiesSubIdErrorByTypeAndID
       parameters:
-        - $ref: '#/components/parameters/Type'
-        - $ref: '#/components/parameters/ID'
-        - $ref: '#/components/parameters/SubId'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/Type"
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/SubId"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ErrorInformationObject'
+              $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /transactionRequests:
     post:
       description: >-
@@ -887,55 +911,55 @@ paths:
         - transactionRequests
       operationId: TransactionRequests
       parameters:
-        - $ref: '#/components/parameters/Accept'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/Accept"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Transaction request to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TransactionRequestsPostRequest'
+              $ref: "#/components/schemas/TransactionRequestsPostRequest"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /transactionRequests/{ID}:
     parameters:
-      - $ref: '#/components/parameters/ID'
-      - $ref: '#/components/parameters/Content-Type'
-      - $ref: '#/components/parameters/Date'
-      - $ref: '#/components/parameters/X-Forwarded-For'
-      - $ref: '#/components/parameters/FSPIOP-Source'
-      - $ref: '#/components/parameters/FSPIOP-Destination'
-      - $ref: '#/components/parameters/FSPIOP-Encryption'
-      - $ref: '#/components/parameters/FSPIOP-Signature'
-      - $ref: '#/components/parameters/FSPIOP-URI'
-      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      - $ref: "#/components/parameters/ID"
+      - $ref: "#/components/parameters/Content-Type"
+      - $ref: "#/components/parameters/Date"
+      - $ref: "#/components/parameters/X-Forwarded-For"
+      - $ref: "#/components/parameters/FSPIOP-Source"
+      - $ref: "#/components/parameters/FSPIOP-Destination"
+      - $ref: "#/components/parameters/FSPIOP-Encryption"
+      - $ref: "#/components/parameters/FSPIOP-Signature"
+      - $ref: "#/components/parameters/FSPIOP-URI"
+      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
       description: >-
         The HTTP request `GET /transactionRequests/{ID}` is used to get
@@ -947,26 +971,26 @@ paths:
         - transactionRequests
       operationId: TransactionRequestsByID
       parameters:
-        - $ref: '#/components/parameters/Accept'
+        - $ref: "#/components/parameters/Accept"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     put:
       description: >-
         The callback `PUT /transactionRequests/{ID}` is used to inform the
@@ -979,33 +1003,33 @@ paths:
         - transactionRequests
       operationId: TransactionRequestsByIDPut
       parameters:
-        - $ref: '#/components/parameters/Content-Length'
+        - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Transaction request information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TransactionRequestsIDPutResponse'
+              $ref: "#/components/schemas/TransactionRequestsIDPutResponse"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /transactionRequests/{ID}/error:
     put:
       description: >-
@@ -1020,43 +1044,43 @@ paths:
         - transactionRequests
       operationId: TransactionRequestsErrorByID
       parameters:
-        - $ref: '#/components/parameters/ID'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ErrorInformationObject'
+              $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /quotes:
     post:
       description: >-
@@ -1067,55 +1091,55 @@ paths:
         - quotes
       operationId: Quotes
       parameters:
-        - $ref: '#/components/parameters/Accept'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/Accept"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the quote to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/QuotesPostRequest'
+              $ref: "#/components/schemas/QuotesPostRequest"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /quotes/{ID}:
     parameters:
-      - $ref: '#/components/parameters/ID'
-      - $ref: '#/components/parameters/Content-Type'
-      - $ref: '#/components/parameters/Date'
-      - $ref: '#/components/parameters/X-Forwarded-For'
-      - $ref: '#/components/parameters/FSPIOP-Source'
-      - $ref: '#/components/parameters/FSPIOP-Destination'
-      - $ref: '#/components/parameters/FSPIOP-Encryption'
-      - $ref: '#/components/parameters/FSPIOP-Signature'
-      - $ref: '#/components/parameters/FSPIOP-URI'
-      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      - $ref: "#/components/parameters/ID"
+      - $ref: "#/components/parameters/Content-Type"
+      - $ref: "#/components/parameters/Date"
+      - $ref: "#/components/parameters/X-Forwarded-For"
+      - $ref: "#/components/parameters/FSPIOP-Source"
+      - $ref: "#/components/parameters/FSPIOP-Destination"
+      - $ref: "#/components/parameters/FSPIOP-Encryption"
+      - $ref: "#/components/parameters/FSPIOP-Signature"
+      - $ref: "#/components/parameters/FSPIOP-URI"
+      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
       description: >-
         The HTTP request `GET /quotes/{ID}` is used to get information regarding
@@ -1126,26 +1150,26 @@ paths:
         - quotes
       operationId: QuotesByID
       parameters:
-        - $ref: '#/components/parameters/Accept'
+        - $ref: "#/components/parameters/Accept"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     put:
       description: >-
         The callback `PUT /quotes/{ID}` is used to inform the client of a
@@ -1157,33 +1181,33 @@ paths:
         - quotes
       operationId: QuotesByID1
       parameters:
-        - $ref: '#/components/parameters/Content-Length'
+        - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Quote information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/QuotesIDPutResponse'
+              $ref: "#/components/schemas/QuotesIDPutResponse"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /quotes/{ID}/error:
     put:
       description: >-
@@ -1197,55 +1221,55 @@ paths:
         - quotes
       operationId: QuotesByIDAndError
       parameters:
-        - $ref: '#/components/parameters/ID'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ErrorInformationObject'
+              $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /authorizations/{ID}:
     parameters:
-      - $ref: '#/components/parameters/ID'
-      - $ref: '#/components/parameters/Content-Type'
-      - $ref: '#/components/parameters/Date'
-      - $ref: '#/components/parameters/X-Forwarded-For'
-      - $ref: '#/components/parameters/FSPIOP-Source'
-      - $ref: '#/components/parameters/FSPIOP-Destination'
-      - $ref: '#/components/parameters/FSPIOP-Encryption'
-      - $ref: '#/components/parameters/FSPIOP-Signature'
-      - $ref: '#/components/parameters/FSPIOP-URI'
-      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      - $ref: "#/components/parameters/ID"
+      - $ref: "#/components/parameters/Content-Type"
+      - $ref: "#/components/parameters/Date"
+      - $ref: "#/components/parameters/X-Forwarded-For"
+      - $ref: "#/components/parameters/FSPIOP-Source"
+      - $ref: "#/components/parameters/FSPIOP-Destination"
+      - $ref: "#/components/parameters/FSPIOP-Encryption"
+      - $ref: "#/components/parameters/FSPIOP-Signature"
+      - $ref: "#/components/parameters/FSPIOP-URI"
+      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
       description: >-
         The HTTP request `GET /authorizations/{ID}` is used to request the Payer
@@ -1289,26 +1313,26 @@ paths:
         - authorizations
       operationId: AuthorizationsByIDGet
       parameters:
-        - $ref: '#/components/parameters/Accept'
+        - $ref: "#/components/parameters/Accept"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     put:
       description: >-
         The callback `PUT /authorizations/{ID}` is used to inform the client of
@@ -1320,33 +1344,33 @@ paths:
         - authorizations
       operationId: AuthorizationsByIDPut
       parameters:
-        - $ref: '#/components/parameters/Content-Length'
+        - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Authorization result returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AuthorizationsIDPutResponse'
+              $ref: "#/components/schemas/AuthorizationsIDPutResponse"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /authorizations/{ID}/error:
     put:
       description: >-
@@ -1359,43 +1383,43 @@ paths:
         - authorizations
       operationId: AuthorizationsByIDAndError
       parameters:
-        - $ref: '#/components/parameters/ID'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ErrorInformationObject'
+              $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /transfers:
     post:
       description: >-
@@ -1407,55 +1431,55 @@ paths:
         - transfers
       operationId: transfers
       parameters:
-        - $ref: '#/components/parameters/Accept'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/Accept"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the transfer to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TransfersPostRequest'
+              $ref: "#/components/schemas/TransfersPostRequest"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /transfers/{ID}:
     parameters:
-      - $ref: '#/components/parameters/ID'
-      - $ref: '#/components/parameters/Content-Type'
-      - $ref: '#/components/parameters/Date'
-      - $ref: '#/components/parameters/X-Forwarded-For'
-      - $ref: '#/components/parameters/FSPIOP-Source'
-      - $ref: '#/components/parameters/FSPIOP-Destination'
-      - $ref: '#/components/parameters/FSPIOP-Encryption'
-      - $ref: '#/components/parameters/FSPIOP-Signature'
-      - $ref: '#/components/parameters/FSPIOP-URI'
-      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      - $ref: "#/components/parameters/ID"
+      - $ref: "#/components/parameters/Content-Type"
+      - $ref: "#/components/parameters/Date"
+      - $ref: "#/components/parameters/X-Forwarded-For"
+      - $ref: "#/components/parameters/FSPIOP-Source"
+      - $ref: "#/components/parameters/FSPIOP-Destination"
+      - $ref: "#/components/parameters/FSPIOP-Encryption"
+      - $ref: "#/components/parameters/FSPIOP-Signature"
+      - $ref: "#/components/parameters/FSPIOP-URI"
+      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
       description: >-
         The HTTP request `GET /transfers/{ID}` is used to get information
@@ -1467,26 +1491,26 @@ paths:
         - transfers
       operationId: TransfersByIDGet
       parameters:
-        - $ref: '#/components/parameters/Accept'
+        - $ref: "#/components/parameters/Accept"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     patch:
       description: >-
         The HTTP request PATCH /transfers/<ID> is used by a Switch to update the
@@ -1500,33 +1524,33 @@ paths:
         - transfers
       operationId: TransfersByIDPatch
       parameters:
-        - $ref: '#/components/parameters/Content-Length'
+        - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Transfer notification upon completion.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TransfersIDPatchResponse'
+              $ref: "#/components/schemas/TransfersIDPatchResponse"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     put:
       description: >-
         The callback `PUT /transfers/{ID}` is used to inform the client of a
@@ -1538,33 +1562,33 @@ paths:
         - transfers
       operationId: TransfersByIDPut
       parameters:
-        - $ref: '#/components/parameters/Content-Length'
+        - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Transfer information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TransfersIDPutResponse'
+              $ref: "#/components/schemas/TransfersIDPutResponse"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /transfers/{ID}/error:
     put:
       description: >-
@@ -1578,55 +1602,55 @@ paths:
         - transfers
       operationId: TransfersByIDAndError
       parameters:
-        - $ref: '#/components/parameters/ID'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ErrorInformationObject'
+              $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /transactions/{ID}:
     parameters:
-      - $ref: '#/components/parameters/ID'
-      - $ref: '#/components/parameters/Content-Type'
-      - $ref: '#/components/parameters/Date'
-      - $ref: '#/components/parameters/X-Forwarded-For'
-      - $ref: '#/components/parameters/FSPIOP-Source'
-      - $ref: '#/components/parameters/FSPIOP-Destination'
-      - $ref: '#/components/parameters/FSPIOP-Encryption'
-      - $ref: '#/components/parameters/FSPIOP-Signature'
-      - $ref: '#/components/parameters/FSPIOP-URI'
-      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      - $ref: "#/components/parameters/ID"
+      - $ref: "#/components/parameters/Content-Type"
+      - $ref: "#/components/parameters/Date"
+      - $ref: "#/components/parameters/X-Forwarded-For"
+      - $ref: "#/components/parameters/FSPIOP-Source"
+      - $ref: "#/components/parameters/FSPIOP-Destination"
+      - $ref: "#/components/parameters/FSPIOP-Encryption"
+      - $ref: "#/components/parameters/FSPIOP-Signature"
+      - $ref: "#/components/parameters/FSPIOP-URI"
+      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
       description: >-
         The HTTP request `GET /transactions/{ID}` is used to get transaction
@@ -1639,26 +1663,26 @@ paths:
         - transactions
       operationId: TransactionsByID
       parameters:
-        - $ref: '#/components/parameters/Accept'
+        - $ref: "#/components/parameters/Accept"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     put:
       description: >-
         The callback `PUT /transactions/{ID}` is used to inform the client of a
@@ -1669,33 +1693,33 @@ paths:
         - transactions
       operationId: TransactionsByID1
       parameters:
-        - $ref: '#/components/parameters/Content-Length'
+        - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Transaction information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TransactionsIDPutResponse'
+              $ref: "#/components/schemas/TransactionsIDPutResponse"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /transactions/{ID}/error:
     put:
       description: >-
@@ -1708,43 +1732,43 @@ paths:
         - transactions
       operationId: TransactionsErrorByID
       parameters:
-        - $ref: '#/components/parameters/ID'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ErrorInformationObject'
+              $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /bulkQuotes:
     post:
       description: >-
@@ -1755,55 +1779,55 @@ paths:
         - bulkQuotes
       operationId: BulkQuotes
       parameters:
-        - $ref: '#/components/parameters/Accept'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/Accept"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the bulk quote to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BulkQuotesPostRequest'
+              $ref: "#/components/schemas/BulkQuotesPostRequest"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /bulkQuotes/{ID}:
     parameters:
-      - $ref: '#/components/parameters/ID'
-      - $ref: '#/components/parameters/Content-Type'
-      - $ref: '#/components/parameters/Date'
-      - $ref: '#/components/parameters/X-Forwarded-For'
-      - $ref: '#/components/parameters/FSPIOP-Source'
-      - $ref: '#/components/parameters/FSPIOP-Destination'
-      - $ref: '#/components/parameters/FSPIOP-Encryption'
-      - $ref: '#/components/parameters/FSPIOP-Signature'
-      - $ref: '#/components/parameters/FSPIOP-URI'
-      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      - $ref: "#/components/parameters/ID"
+      - $ref: "#/components/parameters/Content-Type"
+      - $ref: "#/components/parameters/Date"
+      - $ref: "#/components/parameters/X-Forwarded-For"
+      - $ref: "#/components/parameters/FSPIOP-Source"
+      - $ref: "#/components/parameters/FSPIOP-Destination"
+      - $ref: "#/components/parameters/FSPIOP-Encryption"
+      - $ref: "#/components/parameters/FSPIOP-Signature"
+      - $ref: "#/components/parameters/FSPIOP-URI"
+      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
       description: >-
         The HTTP request `GET /bulkQuotes/{ID}` is used to get information
@@ -1815,26 +1839,26 @@ paths:
         - bulkQuotes
       operationId: BulkQuotesByID
       parameters:
-        - $ref: '#/components/parameters/Accept'
+        - $ref: "#/components/parameters/Accept"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     put:
       description: >-
         The callback `PUT /bulkQuotes/{ID}` is used to inform the client of a
@@ -1846,33 +1870,33 @@ paths:
         - bulkQuotes
       operationId: BulkQuotesByID1
       parameters:
-        - $ref: '#/components/parameters/Content-Length'
+        - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Bulk quote information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BulkQuotesIDPutResponse'
+              $ref: "#/components/schemas/BulkQuotesIDPutResponse"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /bulkQuotes/{ID}/error:
     put:
       description: >-
@@ -1886,43 +1910,43 @@ paths:
         - bulkQuotes
       operationId: BulkQuotesErrorByID
       parameters:
-        - $ref: '#/components/parameters/ID'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ErrorInformationObject'
+              $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /bulkTransfers:
     post:
       description: >-
@@ -1933,55 +1957,55 @@ paths:
         - bulkTransfers
       operationId: BulkTransfers
       parameters:
-        - $ref: '#/components/parameters/Accept'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/Accept"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the bulk transfer to be created.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BulkTransfersPostRequest'
+              $ref: "#/components/schemas/BulkTransfersPostRequest"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /bulkTransfers/{ID}:
     parameters:
-      - $ref: '#/components/parameters/ID'
-      - $ref: '#/components/parameters/Content-Type'
-      - $ref: '#/components/parameters/Date'
-      - $ref: '#/components/parameters/X-Forwarded-For'
-      - $ref: '#/components/parameters/FSPIOP-Source'
-      - $ref: '#/components/parameters/FSPIOP-Destination'
-      - $ref: '#/components/parameters/FSPIOP-Encryption'
-      - $ref: '#/components/parameters/FSPIOP-Signature'
-      - $ref: '#/components/parameters/FSPIOP-URI'
-      - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+      - $ref: "#/components/parameters/ID"
+      - $ref: "#/components/parameters/Content-Type"
+      - $ref: "#/components/parameters/Date"
+      - $ref: "#/components/parameters/X-Forwarded-For"
+      - $ref: "#/components/parameters/FSPIOP-Source"
+      - $ref: "#/components/parameters/FSPIOP-Destination"
+      - $ref: "#/components/parameters/FSPIOP-Encryption"
+      - $ref: "#/components/parameters/FSPIOP-Signature"
+      - $ref: "#/components/parameters/FSPIOP-URI"
+      - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
     get:
       description: >-
         The HTTP request `GET /bulkTransfers/{ID}` is used to get information
@@ -1993,26 +2017,26 @@ paths:
         - bulkTransfers
       operationId: BulkTransferByID
       parameters:
-        - $ref: '#/components/parameters/Accept'
+        - $ref: "#/components/parameters/Accept"
       responses:
-        '202':
-          $ref: '#/components/responses/202'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "202":
+          $ref: "#/components/responses/202"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
     put:
       description: >-
         The callback `PUT /bulkTransfers/{ID}` is used to inform the client of a
@@ -2025,33 +2049,33 @@ paths:
         - bulkTransfers
       operationId: BulkTransfersByIDPut
       parameters:
-        - $ref: '#/components/parameters/Content-Length'
+        - $ref: "#/components/parameters/Content-Length"
       requestBody:
         description: Bulk transfer information returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/BulkTransfersIDPutResponse'
+              $ref: "#/components/schemas/BulkTransfersIDPutResponse"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
   /bulkTransfers/{ID}/error:
     put:
       description: >-
@@ -2066,45 +2090,141 @@ paths:
         - bulkTransfers
       operationId: BulkTransfersErrorByID
       parameters:
-        - $ref: '#/components/parameters/ID'
-        - $ref: '#/components/parameters/Content-Length'
-        - $ref: '#/components/parameters/Content-Type'
-        - $ref: '#/components/parameters/Date'
-        - $ref: '#/components/parameters/X-Forwarded-For'
-        - $ref: '#/components/parameters/FSPIOP-Source'
-        - $ref: '#/components/parameters/FSPIOP-Destination'
-        - $ref: '#/components/parameters/FSPIOP-Encryption'
-        - $ref: '#/components/parameters/FSPIOP-Signature'
-        - $ref: '#/components/parameters/FSPIOP-URI'
-        - $ref: '#/components/parameters/FSPIOP-HTTP-Method'
+        - $ref: "#/components/parameters/ID"
+        - $ref: "#/components/parameters/Content-Length"
+        - $ref: "#/components/parameters/Content-Type"
+        - $ref: "#/components/parameters/Date"
+        - $ref: "#/components/parameters/X-Forwarded-For"
+        - $ref: "#/components/parameters/FSPIOP-Source"
+        - $ref: "#/components/parameters/FSPIOP-Destination"
+        - $ref: "#/components/parameters/FSPIOP-Encryption"
+        - $ref: "#/components/parameters/FSPIOP-Signature"
+        - $ref: "#/components/parameters/FSPIOP-URI"
+        - $ref: "#/components/parameters/FSPIOP-HTTP-Method"
       requestBody:
         description: Details of the error returned.
         required: true
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ErrorInformationObject'
+              $ref: "#/components/schemas/ErrorInformationObject"
       responses:
-        '200':
-          $ref: '#/components/responses/200'
-        '400':
-          $ref: '#/components/responses/400'
-        '401':
-          $ref: '#/components/responses/401'
-        '403':
-          $ref: '#/components/responses/403'
-        '404':
-          $ref: '#/components/responses/404'
-        '405':
-          $ref: '#/components/responses/405'
-        '406':
-          $ref: '#/components/responses/406'
-        '501':
-          $ref: '#/components/responses/501'
-        '503':
-          $ref: '#/components/responses/503'
+        "200":
+          $ref: "#/components/responses/200"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/403"
+        "404":
+          $ref: "#/components/responses/404"
+        "405":
+          $ref: "#/components/responses/405"
+        "406":
+          $ref: "#/components/responses/406"
+        "501":
+          $ref: "#/components/responses/501"
+        "503":
+          $ref: "#/components/responses/503"
 components:
   schemas:
+    Amount:
+      title: Amount
+      type: string
+      pattern: ^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$
+      description: >-
+        The API data type Amount is a JSON String in a canonical format that is
+        restricted by a regular expression for interoperability reasons. This
+        pattern does not allow any trailing zeroes at all, but allows an amount
+        without a minor currency unit. It also only allows four digits in the
+        minor currency unit; a negative value is not allowed. Using more than 18
+        digits in the major currency unit is not allowed.
+      example: "123.45"
+    AmountType:
+      title: AmountType
+      type: string
+      enum:
+        - SEND
+        - RECEIVE
+      description: >-
+        Below are the allowed values for the enumeration AmountType.
+
+        - SEND - Amount the Payer would like to send, that is, the amount that
+        should be withdrawn from the Payer account including any fees.
+
+        - RECEIVE - Amount the Payer would like the Payee to receive, that is,
+        the amount that should be sent to the receiver exclusive of any fees.
+      example: RECEIVE
+    AuthenticationInfo:
+      title: AuthenticationInfo
+      type: object
+      description: Data model for the complex type AuthenticationInfo.
+      properties:
+        authentication:
+          $ref: "#/components/schemas/AuthenticationType"
+        authenticationValue:
+          $ref: "#/components/schemas/AuthenticationValue"
+      required:
+        - authentication
+        - authenticationValue
+    AuthenticationType:
+      title: AuthenticationType
+      type: string
+      enum:
+        - OTP
+        - QRCODE
+        - U2F
+      description: |-
+        Below are the allowed values for the enumeration AuthenticationType.
+        - OTP - One-time password generated by the Payer FSP.
+        - QRCODE - QR code used as One Time Password.
+        - U2F - U2F is a new addition isolated to Thirdparty stream.
+      example: OTP
+    AuthenticationValue:
+      title: AuthenticationValue
+      anyOf:
+        - $ref: "#/components/schemas/OtpValue"
+        - $ref: "#/components/schemas/QRCODE"
+        - $ref: "#/components/schemas/U2FPinValue"
+      pattern: ^\d{3,10}$|^\S{1,64}$
+      description: >-
+        Contains the authentication value. The format depends on the
+        authentication type used in the AuthenticationInfo complex type.
+    AuthorizationResponse:
+      title: AuthorizationResponse
+      type: string
+      enum:
+        - ENTERED
+        - REJECTED
+        - RESEND
+      description: |-
+        Below are the allowed values for the enumeration.
+        - ENTERED - Consumer entered the authentication value.
+        - REJECTED - Consumer rejected the transaction.
+        - RESEND - Consumer requested to resend the authentication value.
+      example: ENTERED
+    AuthorizationsIDPutResponse:
+      title: AuthorizationsIDPutResponse
+      type: object
+      description: The object sent in the PUT /authorizations/{ID} callback.
+      properties:
+        authenticationInfo:
+          $ref: "#/components/schemas/AuthenticationInfo"
+        responseType:
+          $ref: "#/components/schemas/AuthorizationResponse"
+      required:
+        - responseType
+    BalanceOfPayments:
+      title: BalanceOfPayments
+      type: string
+      pattern: ^[1-9]\d{2}$
+      description: >-
+        (BopCode) The API data type
+        [BopCode](https://www.imf.org/external/np/sta/bopcode/) is a JSON String
+        of 3 characters, consisting of digits only. Negative numbers are not
+        allowed. A leading zero is not allowed.
+      example: "123"
     BinaryString:
       type: string
       pattern: ^[A-Za-z0-9-_]+[=]{0,2}$
@@ -2122,107 +2242,133 @@ components:
         type BinaryString, where the raw underlying data is always of 32 bytes.
         The data type BinaryString32 should not use a padding character as the
         size of the underlying data is fixed.
-    Date:
-      title: Date
-      type: string
-      pattern: >-
-        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
-      description: >-
-        The API data type Date is a JSON String in a lexical format that is
-        restricted by a regular expression for interoperability reasons. This
-        format, as specified in ISO 8601, contains a date only. A more readable
-        version of the format is yyyy-MM-dd. Examples are "1982-05-23",
-        "1987-08-05”.
-    Integer:
-      title: Integer
-      type: string
-      pattern: ^[1-9]\d*$
-      description: >-
-        The API data type Integer is a JSON String consisting of digits only.
-        Negative numbers and leading zeroes are not allowed. The data type is
-        always limited to a specific number of digits.
-    Name:
-      title: Name
-      type: string
-      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
-      description: >-
-        The API data type Name is a JSON String, restricted by a regular
-        expression to avoid characters which are generally not used in a name.
-
-
-        Regular Expression - The regular expression for restricting the Name
-        type is "^(?!\s*$)[\w .,'-]{1,128}$". The restriction does not allow a
-        string consisting of whitespace only, all Unicode characters are
-        allowed, as well as the period (.) (apostrophe (‘), dash (-), comma (,)
-        and space characters ( ).
-
-
-        **Note:** In some programming languages, Unicode support must be
-        specifically enabled. For example, if Java is used, the flag
-        UNICODE_CHARACTER_CLASS must be enabled to allow Unicode characters.
-    PersonalIdentifierType:
-      title: PersonalIdentifierType
+    BulkQuotesIDPutResponse:
+      title: BulkQuotesIDPutResponse
+      type: object
+      description: The object sent in the PUT /bulkQuotes/{ID} callback.
+      properties:
+        individualQuoteResults:
+          type: array
+          maxItems: 1000
+          items:
+            $ref: "#/components/schemas/IndividualQuoteResult"
+          description: >-
+            Fees for each individual transaction, if any of them are charged per
+            transaction.
+        expiration:
+          $ref: "#/components/schemas/DateTime"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - expiration
+    BulkQuotesPostRequest:
+      title: BulkQuotesPostRequest
+      type: object
+      description: The object sent in the POST /bulkQuotes request.
+      properties:
+        bulkQuoteId:
+          $ref: "#/components/schemas/CorrelationId"
+        payer:
+          $ref: "#/components/schemas/Party"
+        geoCode:
+          $ref: "#/components/schemas/GeoCode"
+        expiration:
+          $ref: "#/components/schemas/DateTime"
+        individualQuotes:
+          type: array
+          minItems: 1
+          maxItems: 1000
+          items:
+            $ref: "#/components/schemas/IndividualQuote"
+          description: List of quotes elements.
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - bulkQuoteId
+        - payer
+        - individualQuotes
+    BulkTransferState:
+      title: BulkTransactionState
       type: string
       enum:
-        - PASSPORT
-        - NATIONAL_REGISTRATION
-        - DRIVING_LICENSE
-        - ALIEN_REGISTRATION
-        - NATIONAL_ID_CARD
-        - EMPLOYER_ID
-        - TAX_ID_NUMBER
-        - SENIOR_CITIZENS_CARD
-        - MARRIAGE_CERTIFICATE
-        - HEALTH_CARD
-        - VOTERS_ID
-        - UNITED_NATIONS
-        - OTHER_ID
+        - RECEIVED
+        - PENDING
+        - ACCEPTED
+        - PROCESSING
+        - COMPLETED
+        - REJECTED
       description: >-
         Below are the allowed values for the enumeration.
 
-        - PASSPORT - A passport number is used as reference to a Party.
+        - RECEIVED - Payee FSP has received the bulk transfer from the Payer
+        FSP.
 
-        - NATIONAL_REGISTRATION - A national registration number is used as
-        reference to a Party.
+        - PENDING - Payee FSP has validated the bulk transfer.
 
-        - DRIVING_LICENSE - A driving license is used as reference to a Party.
+        - ACCEPTED - Payee FSP has accepted to process the bulk transfer.
 
-        - ALIEN_REGISTRATION - An alien registration number is used as reference
-        to a Party.
+        - PROCESSING - Payee FSP has started to transfer fund to the Payees.
 
-        - NATIONAL_ID_CARD - A national ID card number is used as reference to a
-        Party.
+        - COMPLETED - Payee FSP has completed transfer of funds to the Payees.
 
-        - EMPLOYER_ID - A tax identification number is used as reference to a
-        Party.
-
-        - TAX_ID_NUMBER - A tax identification number is used as reference to a
-        Party.
-
-        - SENIOR_CITIZENS_CARD - A senior citizens card number is used as
-        reference to a Party.
-
-        - MARRIAGE_CERTIFICATE - A marriage certificate number is used as
-        reference to a Party.
-
-        - HEALTH_CARD - A health card number is used as reference to a Party.
-
-        - VOTERS_ID - A voter’s identification number is used as reference to a
-        Party.
-
-        - UNITED_NATIONS - An UN (United Nations) number is used as reference to
-        a Party.
-
-        - OTHER_ID - Any other type of identification type number is used as
-        reference to a Party.
-    TokenCode:
-      title: TokenCode
+        - REJECTED - Payee FSP has rejected to process the bulk transfer.
+      example: RECEIVED
+    BulkTransfersIDPutResponse:
+      title: BulkTransfersIDPutResponse
+      type: object
+      description: The object sent in the PUT /bulkTransfers/{ID} callback.
+      properties:
+        completedTimestamp:
+          $ref: "#/components/schemas/DateTime"
+        individualTransferResults:
+          type: array
+          maxItems: 1000
+          items:
+            $ref: "#/components/schemas/IndividualTransferResult"
+          description: List of IndividualTransferResult elements.
+        bulkTransferState:
+          $ref: "#/components/schemas/BulkTransferState"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - bulkTransferState
+    BulkTransfersPostRequest:
+      title: BulkTransfersPostRequest
+      type: object
+      description: The object sent in the POST /bulkTransfers request.
+      properties:
+        bulkTransferId:
+          $ref: "#/components/schemas/CorrelationId"
+        bulkQuoteId:
+          $ref: "#/components/schemas/CorrelationId"
+        payerFsp:
+          $ref: "#/components/schemas/FspId"
+        payeeFsp:
+          $ref: "#/components/schemas/FspId"
+        individualTransfers:
+          type: array
+          minItems: 1
+          maxItems: 1000
+          items:
+            $ref: "#/components/schemas/IndividualTransfer"
+          description: List of IndividualTransfer elements.
+        expiration:
+          $ref: "#/components/schemas/DateTime"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - bulkTransferId
+        - bulkQuoteId
+        - payerFsp
+        - payeeFsp
+        - individualTransfers
+        - expiration
+    Code:
+      title: Code
       type: string
       pattern: ^[0-9a-zA-Z]{4,32}$
-      description: >-
-        The API data type TokenCode is a JSON String between 4 and 32
-        characters, consisting of digits or upper- or lowercase characters from
-        a to z.
+      description: Any code/token returned by the Payee FSP (TokenCode Type).
+      example: Test-Code
     CorrelationId:
       title: CorrelationId
       type: string
@@ -2236,231 +2382,6 @@ components:
         regular expression for interoperability reasons. A UUID is always 36
         characters long, 32 hexadecimal symbols and 4 dashes (‘-‘).
       example: b51ec534-ee48-4575-b6a9-ead2955b8069
-    PartyIdType:
-      title: PartyIdType
-      type: string
-      enum:
-        - MSISDN
-        - EMAIL
-        - PERSONAL_ID
-        - BUSINESS
-        - DEVICE
-        - ACCOUNT_ID
-        - IBAN
-        - ALIAS
-      description: >-
-        Below are the allowed values for the enumeration.
-
-        - MSISDN - An MSISDN (Mobile Station International Subscriber Directory
-        Number, that is, the phone number) is used as reference to a
-        participant. The MSISDN identifier should be in international format
-        according to the [ITU-T E.164
-        standard](https://www.itu.int/rec/T-REC-E.164/en). Optionally, the
-        MSISDN may be prefixed by a single plus sign, indicating the
-        international prefix.
-
-        - EMAIL - An email is used as reference to a participant. The format of
-        the email should be according to the informational [RFC
-        3696](https://tools.ietf.org/html/rfc3696).
-
-        - PERSONAL_ID - A personal identifier is used as reference to a
-        participant. Examples of personal identification are passport number,
-        birth certificate number, and national registration number. The
-        identifier number is added in the PartyIdentifier element. The personal
-        identifier type is added in the PartySubIdOrType element.
-
-        - BUSINESS - A specific Business (for example, an organization or a
-        company) is used as reference to a participant. The BUSINESS identifier
-        can be in any format. To make a transaction connected to a specific
-        username or bill number in a Business, the PartySubIdOrType element
-        should be used.
-
-        - DEVICE - A specific device (for example, a POS or ATM) ID connected to
-        a specific business or organization is used as reference to a Party. For
-        referencing a specific device under a specific business or organization,
-        use the PartySubIdOrType element.
-
-        - ACCOUNT_ID - A bank account number or FSP account ID should be used as
-        reference to a participant. The ACCOUNT_ID identifier can be in any
-        format, as formats can greatly differ depending on country and FSP.
-
-        - IBAN - A bank account number or FSP account ID is used as reference to
-        a participant. The IBAN identifier can consist of up to 34 alphanumeric
-        characters and should be entered without whitespace.
-
-        - ALIAS An alias is used as reference to a participant. The alias should
-        be created in the FSP as an alternative reference to an account owner.
-        Another example of an alias is a username in the FSP system. The ALIAS
-        identifier can be in any format. It is also possible to use the
-        PartySubIdOrType element for identifying an account under an Alias
-        defined by the PartyIdentifier.
-    PartyIdentifier:
-      title: PartyIdentifier
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Identifier of the Party.
-      example: '16135551212'
-    PartySubIdOrType:
-      title: PartySubIdOrType
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: >-
-        Either a sub-identifier of a PartyIdentifier, or a sub-type of the
-        PartyIdType, normally a PersonalIdentifierType.
-    FspId:
-      title: FspId
-      type: string
-      minLength: 1
-      maxLength: 32
-      description: FSP identifier.
-    ExtensionKey:
-      title: ExtensionKey
-      type: string
-      minLength: 1
-      maxLength: 32
-      description: Extension key.
-    ExtensionValue:
-      title: ExtensionValue
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Extension value.
-    Extension:
-      title: Extension
-      type: object
-      description: Data model for the complex type Extension.
-      properties:
-        key:
-          $ref: '#/components/schemas/ExtensionKey'
-        value:
-          $ref: '#/components/schemas/ExtensionValue'
-      required:
-        - key
-        - value
-    ExtensionList:
-      title: ExtensionList
-      type: object
-      description: >-
-        Data model for the complex type ExtensionList. An optional list of
-        extensions, specific to deployment.
-      properties:
-        extension:
-          type: array
-          items:
-            $ref: '#/components/schemas/Extension'
-          minItems: 1
-          maxItems: 16
-          description: Number of Extension elements.
-      required:
-        - extension
-    PartyIdInfo:
-      title: PartyIdInfo
-      type: object
-      description: >-
-        Data model for the complex type PartyIdInfo. An ExtensionList element
-        has been added to this reqeust in version v1.1
-      properties:
-        partyIdType:
-          $ref: '#/components/schemas/PartyIdType'
-        partyIdentifier:
-          $ref: '#/components/schemas/PartyIdentifier'
-        partySubIdOrType:
-          $ref: '#/components/schemas/PartySubIdOrType'
-        fspId:
-          $ref: '#/components/schemas/FspId'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - partyIdType
-        - partyIdentifier
-    MerchantClassificationCode:
-      title: MerchantClassificationCode
-      type: string
-      pattern: ^[\d]{1,4}$
-      description: >-
-        A limited set of pre-defined numbers. This list would be a limited set
-        of numbers identifying a set of popular merchant types like School Fees,
-        Pubs and Restaurants, Groceries, etc.
-    PartyName:
-      title: PartyName
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Name of the Party. Could be a real name or a nickname.
-    FirstName:
-      title: FirstName
-      type: string
-      minLength: 1
-      maxLength: 128
-      pattern: >-
-        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
-        .,''-]{1,128}$
-      description: First name of the Party (Name Type).
-      example: Henrik
-    MiddleName:
-      title: MiddleName
-      type: string
-      minLength: 1
-      maxLength: 128
-      pattern: >-
-        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
-        .,''-]{1,128}$
-      description: Middle name of the Party (Name Type).
-      example: Johannes
-    LastName:
-      title: LastName
-      type: string
-      minLength: 1
-      maxLength: 128
-      pattern: >-
-        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
-        .,''-]{1,128}$
-      description: Last name of the Party (Name Type).
-      example: Karlsson
-    PartyComplexName:
-      title: PartyComplexName
-      type: object
-      description: Data model for the complex type PartyComplexName.
-      properties:
-        firstName:
-          $ref: '#/components/schemas/FirstName'
-        middleName:
-          $ref: '#/components/schemas/MiddleName'
-        lastName:
-          $ref: '#/components/schemas/LastName'
-    DateOfBirth:
-      title: DateofBirth (type Date)
-      type: string
-      pattern: >-
-        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
-      description: Date of Birth of the Party.
-      example: '1966-06-16'
-    PartyPersonalInfo:
-      title: PartyPersonalInfo
-      type: object
-      description: Data model for the complex type PartyPersonalInfo.
-      properties:
-        complexName:
-          $ref: '#/components/schemas/PartyComplexName'
-        dateOfBirth:
-          $ref: '#/components/schemas/DateOfBirth'
-    Party:
-      title: Party
-      type: object
-      description: Data model for the complex type Party.
-      properties:
-        partyIdInfo:
-          $ref: '#/components/schemas/PartyIdInfo'
-        merchantClassificationCode:
-          $ref: '#/components/schemas/MerchantClassificationCode'
-        name:
-          $ref: '#/components/schemas/PartyName'
-        personalInfo:
-          $ref: '#/components/schemas/PartyPersonalInfo'
-      required:
-        - partyIdInfo
     Currency:
       title: Currency
       description: >-
@@ -2636,71 +2557,778 @@ components:
         - ZAR
         - ZMW
         - ZWD
-    Amount:
-      title: Amount
+    Date:
+      title: Date
       type: string
-      pattern: ^([0]|([1-9][0-9]{0,17}))([.][0-9]{0,3}[1-9])?$
+      pattern: >-
+        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
       description: >-
-        The API data type Amount is a JSON String in a canonical format that is
+        The API data type Date is a JSON String in a lexical format that is
         restricted by a regular expression for interoperability reasons. This
-        pattern does not allow any trailing zeroes at all, but allows an amount
-        without a minor currency unit. It also only allows four digits in the
-        minor currency unit; a negative value is not allowed. Using more than 18
-        digits in the major currency unit is not allowed.
-      example: '123.45'
+        format, as specified in ISO 8601, contains a date only. A more readable
+        version of the format is yyyy-MM-dd. Examples are "1982-05-23",
+        "1987-08-05”.
+    DateOfBirth:
+      title: DateofBirth (type Date)
+      type: string
+      pattern: >-
+        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)$
+      description: Date of Birth of the Party.
+      example: "1966-06-16"
+    DateTime:
+      title: DateTime
+      type: string
+      pattern: >-
+        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$
+      description: >-
+        The API data type DateTime is a JSON String in a lexical format that is
+        restricted by a regular expression for interoperability reasons. The
+        format is according to [ISO
+        8601](https://www.iso.org/iso-8601-date-and-time-format.html), expressed
+        in a combined date, time and time zone format. A more readable version
+        of the format is yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]. Examples are
+        "2016-05-24T08:38:08.699-04:00", "2016-05-24T08:38:08.699Z" (where Z
+        indicates Zulu time zone, same as UTC).
+      example: "2016-05-24T08:38:08.699-04:00"
+    ErrorCode:
+      title: ErrorCode
+      type: string
+      pattern: ^[1-9]\d{3}$
+      description: >-
+        The API data type ErrorCode is a JSON String of four characters,
+        consisting of digits only. Negative numbers are not allowed. A leading
+        zero is not allowed. Each error code in the API is a four-digit number,
+        for example, 1234, where the first number (1 in the example) represents
+        the high-level error category, the second number (2 in the example)
+        represents the low-level error category, and the last two numbers (34 in
+        the example) represent the specific error.
+      example: "5100"
+    ErrorDescription:
+      title: ErrorDescription
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Error description string.
+    ErrorInformation:
+      title: ErrorInformation
+      type: object
+      description: Data model for the complex type ErrorInformation.
+      properties:
+        errorCode:
+          $ref: "#/components/schemas/ErrorCode"
+        errorDescription:
+          $ref: "#/components/schemas/ErrorDescription"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - errorCode
+        - errorDescription
+    ErrorInformationObject:
+      title: ErrorInformationObject
+      type: object
+      description: Data model for the complex type object that contains ErrorInformation.
+      properties:
+        errorInformation:
+          $ref: "#/components/schemas/ErrorInformation"
+      required:
+        - errorInformation
+    ErrorInformationResponse:
+      title: ErrorInformationResponse
+      type: object
+      description: >-
+        Data model for the complex type object that contains an optional element
+        ErrorInformation used along with 4xx and 5xx responses.
+      properties:
+        errorInformation:
+          $ref: "#/components/schemas/ErrorInformation"
+    Extension:
+      title: Extension
+      type: object
+      description: Data model for the complex type Extension.
+      properties:
+        key:
+          $ref: "#/components/schemas/ExtensionKey"
+        value:
+          $ref: "#/components/schemas/ExtensionValue"
+      required:
+        - key
+        - value
+    ExtensionKey:
+      title: ExtensionKey
+      type: string
+      minLength: 1
+      maxLength: 32
+      description: Extension key.
+    ExtensionList:
+      title: ExtensionList
+      type: object
+      description: >-
+        Data model for the complex type ExtensionList. An optional list of
+        extensions, specific to deployment.
+      properties:
+        extension:
+          type: array
+          items:
+            $ref: "#/components/schemas/Extension"
+          minItems: 1
+          maxItems: 16
+          description: Number of Extension elements.
+      required:
+        - extension
+    ExtensionValue:
+      title: ExtensionValue
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Extension value.
+    FirstName:
+      title: FirstName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: >-
+        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
+        .,''-]{1,128}$
+      description: First name of the Party (Name Type).
+      example: Henrik
+    FspId:
+      title: FspId
+      type: string
+      minLength: 1
+      maxLength: 32
+      description: FSP identifier.
+    GeoCode:
+      title: GeoCode
+      type: object
+      description: >-
+        Data model for the complex type GeoCode. Indicates the geographic
+        location from where the transaction was initiated.
+      properties:
+        latitude:
+          $ref: "#/components/schemas/Latitude"
+        longitude:
+          $ref: "#/components/schemas/Longitude"
+      required:
+        - latitude
+        - longitude
+    IlpCondition:
+      title: IlpCondition
+      type: string
+      pattern: ^[A-Za-z0-9-_]{43}$
+      maxLength: 48
+      description: Condition that must be attached to the transfer by the Payer.
+    IlpFulfilment:
+      title: IlpFulfilment
+      type: string
+      pattern: ^[A-Za-z0-9-_]{43}$
+      maxLength: 48
+      description: Fulfilment that must be attached to the transfer by the Payee.
+      example: WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8
+    IlpPacket:
+      title: IlpPacket
+      type: string
+      pattern: ^[A-Za-z0-9-_]+[=]{0,2}$
+      minLength: 1
+      maxLength: 32768
+      description: Information for recipient (transport layer information).
+      example: >-
+        AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
+    IndividualQuote:
+      title: IndividualQuote
+      type: object
+      description: Data model for the complex type IndividualQuote.
+      properties:
+        quoteId:
+          $ref: "#/components/schemas/CorrelationId"
+        transactionId:
+          $ref: "#/components/schemas/CorrelationId"
+        payee:
+          $ref: "#/components/schemas/Party"
+        amountType:
+          $ref: "#/components/schemas/AmountType"
+        amount:
+          $ref: "#/components/schemas/Money"
+        fees:
+          $ref: "#/components/schemas/Money"
+        transactionType:
+          $ref: "#/components/schemas/TransactionType"
+        note:
+          $ref: "#/components/schemas/Note"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - quoteId
+        - transactionId
+        - payee
+        - amountType
+        - amount
+        - transactionType
+    IndividualQuoteResult:
+      title: IndividualQuoteResult
+      type: object
+      description: Data model for the complex type IndividualQuoteResult.
+      properties:
+        quoteId:
+          $ref: "#/components/schemas/CorrelationId"
+        payee:
+          $ref: "#/components/schemas/Party"
+        transferAmount:
+          $ref: "#/components/schemas/Money"
+        payeeReceiveAmount:
+          $ref: "#/components/schemas/Money"
+        payeeFspFee:
+          $ref: "#/components/schemas/Money"
+        payeeFspCommission:
+          $ref: "#/components/schemas/Money"
+        ilpPacket:
+          $ref: "#/components/schemas/IlpPacket"
+        condition:
+          $ref: "#/components/schemas/IlpCondition"
+        errorInformation:
+          $ref: "#/components/schemas/ErrorInformation"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - quoteId
+    IndividualTransfer:
+      title: IndividualTransfer
+      type: object
+      description: Data model for the complex type IndividualTransfer.
+      properties:
+        transferId:
+          $ref: "#/components/schemas/CorrelationId"
+        transferAmount:
+          $ref: "#/components/schemas/Money"
+        ilpPacket:
+          $ref: "#/components/schemas/IlpPacket"
+        condition:
+          $ref: "#/components/schemas/IlpCondition"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - transferId
+        - transferAmount
+        - ilpPacket
+        - condition
+    IndividualTransferResult:
+      title: IndividualTransferResult
+      type: object
+      description: Data model for the complex type IndividualTransferResult.
+      properties:
+        transferId:
+          $ref: "#/components/schemas/CorrelationId"
+        fulfilment:
+          $ref: "#/components/schemas/IlpFulfilment"
+        errorInformation:
+          $ref: "#/components/schemas/ErrorInformation"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - transferId
+    Integer:
+      title: Integer
+      type: string
+      pattern: ^[1-9]\d*$
+      description: >-
+        The API data type Integer is a JSON String consisting of digits only.
+        Negative numbers and leading zeroes are not allowed. The data type is
+        always limited to a specific number of digits.
+    LastName:
+      title: LastName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: >-
+        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
+        .,''-]{1,128}$
+      description: Last name of the Party (Name Type).
+      example: Karlsson
+    Latitude:
+      title: Latitude
+      type: string
+      pattern: >-
+        ^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,6})?))$
+      description: >-
+        The API data type Latitude is a JSON String in a lexical format that is
+        restricted by a regular expression for interoperability reasons.
+      example: "+45.4215"
+    Longitude:
+      title: Longitude
+      type: string
+      pattern: >-
+        ^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,6})?))$
+      description: >-
+        The API data type Longitude is a JSON String in a lexical format that is
+        restricted by a regular expression for interoperability reasons.
+      example: "+75.6972"
+    MerchantClassificationCode:
+      title: MerchantClassificationCode
+      type: string
+      pattern: ^[\d]{1,4}$
+      description: >-
+        A limited set of pre-defined numbers. This list would be a limited set
+        of numbers identifying a set of popular merchant types like School Fees,
+        Pubs and Restaurants, Groceries, etc.
+    MiddleName:
+      title: MiddleName
+      type: string
+      minLength: 1
+      maxLength: 128
+      pattern: >-
+        ^(?!\s*$)[\p{L}\p{gc=Mark}\p{digit}\p{gc=Connector_Punctuation}\p{Join_Control}
+        .,''-]{1,128}$
+      description: Middle name of the Party (Name Type).
+      example: Johannes
     Money:
       title: Money
       type: object
       description: Data model for the complex type Money.
       properties:
         currency:
-          $ref: '#/components/schemas/Currency'
+          $ref: "#/components/schemas/Currency"
         amount:
-          $ref: '#/components/schemas/Amount'
+          $ref: "#/components/schemas/Amount"
       required:
         - currency
         - amount
-    TransactionScenario:
-      title: TransactionScenario
+    Name:
+      title: Name
+      type: string
+      pattern: ^(?!\s*$)[\w .,'-]{1,128}$
+      description: >-
+        The API data type Name is a JSON String, restricted by a regular
+        expression to avoid characters which are generally not used in a name.
+
+
+        Regular Expression - The regular expression for restricting the Name
+        type is "^(?!\s*$)[\w .,'-]{1,128}$". The restriction does not allow a
+        string consisting of whitespace only, all Unicode characters are
+        allowed, as well as the period (.) (apostrophe (‘), dash (-), comma (,)
+        and space characters ( ).
+
+
+        **Note:** In some programming languages, Unicode support must be
+        specifically enabled. For example, if Java is used, the flag
+        UNICODE_CHARACTER_CLASS must be enabled to allow Unicode characters.
+    Note:
+      title: Note
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Memo assigned to transaction.
+      example: Note sent to Payee.
+    OtpValue:
+      title: OtpValue
+      type: string
+      pattern: ^\d{3,10}$
+      description: >-
+        The API data type OtpValue is a JSON String of 3 to 10 characters,
+        consisting of digits only. Negative numbers are not allowed. One or more
+        leading zeros are allowed.
+    ParticipantsIDPutResponse:
+      title: ParticipantsIDPutResponse
+      type: object
+      description: The object sent in the PUT /participants/{ID} callback.
+      properties:
+        partyList:
+          type: array
+          items:
+            $ref: "#/components/schemas/PartyResult"
+          minItems: 1
+          maxItems: 10000
+          description: >-
+            List of PartyResult elements that were either created or failed to
+            be created.
+        currency:
+          $ref: "#/components/schemas/Currency"
+      required:
+        - partyList
+    ParticipantsPostRequest:
+      title: ParticipantsPostRequest
+      type: object
+      description: The object sent in the POST /participants request.
+      properties:
+        requestId:
+          $ref: "#/components/schemas/CorrelationId"
+        partyList:
+          type: array
+          items:
+            $ref: "#/components/schemas/PartyIdInfo"
+          minItems: 1
+          maxItems: 10000
+          description: >-
+            List of PartyIdInfo elements that the client would like to update or
+            create FSP information about.
+        currency:
+          $ref: "#/components/schemas/Currency"
+      required:
+        - requestId
+        - partyList
+    ParticipantsTypeIDPutResponse:
+      title: ParticipantsTypeIDPutResponse
+      type: object
+      description: >-
+        The object sent in the PUT /participants/{Type}/{ID}/{SubId} and
+        /participants/{Type}/{ID} callbacks.
+      properties:
+        fspId:
+          $ref: "#/components/schemas/FspId"
+    ParticipantsTypeIDSubIDPostRequest:
+      title: ParticipantsTypeIDSubIDPostRequest
+      type: object
+      description: >-
+        The object sent in the POST /participants/{Type}/{ID}/{SubId} and
+        /participants/{Type}/{ID} requests. An additional optional ExtensionList
+        element has been added as part of v1.1 changes.
+      properties:
+        fspId:
+          $ref: "#/components/schemas/FspId"
+        currency:
+          $ref: "#/components/schemas/Currency"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - fspId
+    PartiesTypeIDPutResponse:
+      title: PartiesTypeIDPutResponse
+      type: object
+      description: The object sent in the PUT /parties/{Type}/{ID} callback.
+      properties:
+        party:
+          $ref: "#/components/schemas/Party"
+      required:
+        - party
+    Party:
+      title: Party
+      type: object
+      description: Data model for the complex type Party.
+      properties:
+        partyIdInfo:
+          $ref: "#/components/schemas/PartyIdInfo"
+        merchantClassificationCode:
+          $ref: "#/components/schemas/MerchantClassificationCode"
+        name:
+          $ref: "#/components/schemas/PartyName"
+        personalInfo:
+          $ref: "#/components/schemas/PartyPersonalInfo"
+      required:
+        - partyIdInfo
+    PartyComplexName:
+      title: PartyComplexName
+      type: object
+      description: Data model for the complex type PartyComplexName.
+      properties:
+        firstName:
+          $ref: "#/components/schemas/FirstName"
+        middleName:
+          $ref: "#/components/schemas/MiddleName"
+        lastName:
+          $ref: "#/components/schemas/LastName"
+    PartyIdInfo:
+      title: PartyIdInfo
+      type: object
+      description: >-
+        Data model for the complex type PartyIdInfo. An ExtensionList element
+        has been added to this reqeust in version v1.1
+      properties:
+        partyIdType:
+          $ref: "#/components/schemas/PartyIdType"
+        partyIdentifier:
+          $ref: "#/components/schemas/PartyIdentifier"
+        partySubIdOrType:
+          $ref: "#/components/schemas/PartySubIdOrType"
+        fspId:
+          $ref: "#/components/schemas/FspId"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - partyIdType
+        - partyIdentifier
+    PartyIdType:
+      title: PartyIdType
       type: string
       enum:
-        - DEPOSIT
-        - WITHDRAWAL
-        - TRANSFER
-        - PAYMENT
-        - REFUND
+        - MSISDN
+        - EMAIL
+        - PERSONAL_ID
+        - BUSINESS
+        - DEVICE
+        - ACCOUNT_ID
+        - IBAN
+        - ALIAS
       description: >-
         Below are the allowed values for the enumeration.
 
-        - DEPOSIT - Used for performing a Cash-In (deposit) transaction. In a
-        normal scenario, electronic funds are transferred from a Business
-        account to a Consumer account, and physical cash is given from the
-        Consumer to the Business User.
+        - MSISDN - An MSISDN (Mobile Station International Subscriber Directory
+        Number, that is, the phone number) is used as reference to a
+        participant. The MSISDN identifier should be in international format
+        according to the [ITU-T E.164
+        standard](https://www.itu.int/rec/T-REC-E.164/en). Optionally, the
+        MSISDN may be prefixed by a single plus sign, indicating the
+        international prefix.
 
-        - WITHDRAWAL - Used for performing a Cash-Out (withdrawal) transaction.
-        In a normal scenario, electronic funds are transferred from a Consumer’s
-        account to a Business account, and physical cash is given from the
-        Business User to the Consumer.
+        - EMAIL - An email is used as reference to a participant. The format of
+        the email should be according to the informational [RFC
+        3696](https://tools.ietf.org/html/rfc3696).
 
-        - TRANSFER - Used for performing a P2P (Peer to Peer, or Consumer to
-        Consumer) transaction.
+        - PERSONAL_ID - A personal identifier is used as reference to a
+        participant. Examples of personal identification are passport number,
+        birth certificate number, and national registration number. The
+        identifier number is added in the PartyIdentifier element. The personal
+        identifier type is added in the PartySubIdOrType element.
 
-        - PAYMENT - Usually used for performing a transaction from a Consumer to
-        a Merchant or Organization, but could also be for a B2B (Business to
-        Business) payment. The transaction could be online for a purchase in an
-        Internet store, in a physical store where both the Consumer and Business
-        User are present, a bill payment, a donation, and so on.
+        - BUSINESS - A specific Business (for example, an organization or a
+        company) is used as reference to a participant. The BUSINESS identifier
+        can be in any format. To make a transaction connected to a specific
+        username or bill number in a Business, the PartySubIdOrType element
+        should be used.
 
-        - REFUND - Used for performing a refund of transaction.
-      example: DEPOSIT
-    TransactionSubScenario:
-      title: TransactionSubScenario
+        - DEVICE - A specific device (for example, a POS or ATM) ID connected to
+        a specific business or organization is used as reference to a Party. For
+        referencing a specific device under a specific business or organization,
+        use the PartySubIdOrType element.
+
+        - ACCOUNT_ID - A bank account number or FSP account ID should be used as
+        reference to a participant. The ACCOUNT_ID identifier can be in any
+        format, as formats can greatly differ depending on country and FSP.
+
+        - IBAN - A bank account number or FSP account ID is used as reference to
+        a participant. The IBAN identifier can consist of up to 34 alphanumeric
+        characters and should be entered without whitespace.
+
+        - ALIAS An alias is used as reference to a participant. The alias should
+        be created in the FSP as an alternative reference to an account owner.
+        Another example of an alias is a username in the FSP system. The ALIAS
+        identifier can be in any format. It is also possible to use the
+        PartySubIdOrType element for identifying an account under an Alias
+        defined by the PartyIdentifier.
+    PartyIdentifier:
+      title: PartyIdentifier
       type: string
-      pattern: ^[A-Z_]{1,32}$
+      minLength: 1
+      maxLength: 128
+      description: Identifier of the Party.
+      example: "16135551212"
+    PartyName:
+      title: PartyName
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Name of the Party. Could be a real name or a nickname.
+    PartyPersonalInfo:
+      title: PartyPersonalInfo
+      type: object
+      description: Data model for the complex type PartyPersonalInfo.
+      properties:
+        complexName:
+          $ref: "#/components/schemas/PartyComplexName"
+        dateOfBirth:
+          $ref: "#/components/schemas/DateOfBirth"
+    PartyResult:
+      title: PartyResult
+      type: object
+      description: Data model for the complex type PartyResult.
+      properties:
+        partyId:
+          $ref: "#/components/schemas/PartyIdInfo"
+        errorInformation:
+          $ref: "#/components/schemas/ErrorInformation"
+      required:
+        - partyId
+    PartySubIdOrType:
+      title: PartySubIdOrType
+      type: string
+      minLength: 1
+      maxLength: 128
       description: >-
-        Possible sub-scenario, defined locally within the scheme (UndefinedEnum
-        Type).
-      example: LOCALLY_DEFINED_SUBSCENARIO
+        Either a sub-identifier of a PartyIdentifier, or a sub-type of the
+        PartyIdType, normally a PersonalIdentifierType.
+    PersonalIdentifierType:
+      title: PersonalIdentifierType
+      type: string
+      enum:
+        - PASSPORT
+        - NATIONAL_REGISTRATION
+        - DRIVING_LICENSE
+        - ALIEN_REGISTRATION
+        - NATIONAL_ID_CARD
+        - EMPLOYER_ID
+        - TAX_ID_NUMBER
+        - SENIOR_CITIZENS_CARD
+        - MARRIAGE_CERTIFICATE
+        - HEALTH_CARD
+        - VOTERS_ID
+        - UNITED_NATIONS
+        - OTHER_ID
+      description: >-
+        Below are the allowed values for the enumeration.
+
+        - PASSPORT - A passport number is used as reference to a Party.
+
+        - NATIONAL_REGISTRATION - A national registration number is used as
+        reference to a Party.
+
+        - DRIVING_LICENSE - A driving license is used as reference to a Party.
+
+        - ALIEN_REGISTRATION - An alien registration number is used as reference
+        to a Party.
+
+        - NATIONAL_ID_CARD - A national ID card number is used as reference to a
+        Party.
+
+        - EMPLOYER_ID - A tax identification number is used as reference to a
+        Party.
+
+        - TAX_ID_NUMBER - A tax identification number is used as reference to a
+        Party.
+
+        - SENIOR_CITIZENS_CARD - A senior citizens card number is used as
+        reference to a Party.
+
+        - MARRIAGE_CERTIFICATE - A marriage certificate number is used as
+        reference to a Party.
+
+        - HEALTH_CARD - A health card number is used as reference to a Party.
+
+        - VOTERS_ID - A voter’s identification number is used as reference to a
+        Party.
+
+        - UNITED_NATIONS - An UN (United Nations) number is used as reference to
+        a Party.
+
+        - OTHER_ID - Any other type of identification type number is used as
+        reference to a Party.
+    QRCODE:
+      title: QRCODE
+      type: string
+      minLength: 1
+      maxLength: 64
+      description: QR code used as a One Time Password.
+    QuotesIDPutResponse:
+      title: QuotesIDPutResponse
+      type: object
+      description: The object sent in the PUT /quotes/{ID} callback.
+      properties:
+        transferAmount:
+          $ref: "#/components/schemas/Money"
+        payeeReceiveAmount:
+          $ref: "#/components/schemas/Money"
+        payeeFspFee:
+          $ref: "#/components/schemas/Money"
+        payeeFspCommission:
+          $ref: "#/components/schemas/Money"
+        expiration:
+          $ref: "#/components/schemas/DateTime"
+        geoCode:
+          $ref: "#/components/schemas/GeoCode"
+        ilpPacket:
+          $ref: "#/components/schemas/IlpPacket"
+        condition:
+          $ref: "#/components/schemas/IlpCondition"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - transferAmount
+        - expiration
+        - ilpPacket
+        - condition
+    QuotesPostRequest:
+      title: QuotesPostRequest
+      type: object
+      description: The object sent in the POST /quotes request.
+      properties:
+        quoteId:
+          $ref: "#/components/schemas/CorrelationId"
+        transactionId:
+          $ref: "#/components/schemas/CorrelationId"
+        transactionRequestId:
+          $ref: "#/components/schemas/CorrelationId"
+        payee:
+          $ref: "#/components/schemas/Party"
+        payer:
+          $ref: "#/components/schemas/Party"
+        amountType:
+          $ref: "#/components/schemas/AmountType"
+        amount:
+          $ref: "#/components/schemas/Money"
+        fees:
+          $ref: "#/components/schemas/Money"
+        transactionType:
+          $ref: "#/components/schemas/TransactionType"
+        geoCode:
+          $ref: "#/components/schemas/GeoCode"
+        note:
+          $ref: "#/components/schemas/Note"
+        expiration:
+          $ref: "#/components/schemas/DateTime"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - quoteId
+        - transactionId
+        - payee
+        - payer
+        - amountType
+        - amount
+        - transactionType
+    Refund:
+      title: Refund
+      type: object
+      description: Data model for the complex type Refund.
+      properties:
+        originalTransactionId:
+          $ref: "#/components/schemas/CorrelationId"
+        refundReason:
+          $ref: "#/components/schemas/RefundReason"
+      required:
+        - originalTransactionId
+    RefundReason:
+      title: RefundReason
+      type: string
+      minLength: 1
+      maxLength: 128
+      description: Reason for the refund.
+      example: Free text indicating reason for the refund.
+    TokenCode:
+      title: TokenCode
+      type: string
+      pattern: ^[0-9a-zA-Z]{4,32}$
+      description: >-
+        The API data type TokenCode is a JSON String between 4 and 32
+        characters, consisting of digits or upper- or lowercase characters from
+        a to z.
+    Transaction:
+      title: Transaction
+      type: object
+      description: >-
+        Data model for the complex type Transaction. The Transaction type is
+        used to carry end-to-end data between the Payer FSP and the Payee FSP in
+        the ILP Packet. Both the transactionId and the quoteId in the data model
+        are decided by the Payer FSP in the POST /quotes request.
+      properties:
+        transactionId:
+          $ref: "#/components/schemas/CorrelationId"
+        quoteId:
+          $ref: "#/components/schemas/CorrelationId"
+        payee:
+          $ref: "#/components/schemas/Party"
+        payer:
+          $ref: "#/components/schemas/Party"
+        amount:
+          $ref: "#/components/schemas/Money"
+        transactionType:
+          $ref: "#/components/schemas/TransactionType"
+        note:
+          $ref: "#/components/schemas/Note"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - transactionId
+        - quoteId
+        - payee
+        - payer
+        - amount
+        - transactionType
     TransactionInitiator:
       title: TransactionInitiator
       type: string
@@ -2734,327 +3362,6 @@ components:
         - BUSINESS - Business is the initiator of the transaction.
         - DEVICE - Device is the initiator of the transaction.
       example: CONSUMER
-    RefundReason:
-      title: RefundReason
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Reason for the refund.
-      example: Free text indicating reason for the refund.
-    Refund:
-      title: Refund
-      type: object
-      description: Data model for the complex type Refund.
-      properties:
-        originalTransactionId:
-          $ref: '#/components/schemas/CorrelationId'
-        refundReason:
-          $ref: '#/components/schemas/RefundReason'
-      required:
-        - originalTransactionId
-    BalanceOfPayments:
-      title: BalanceOfPayments
-      type: string
-      pattern: ^[1-9]\d{2}$
-      description: >-
-        (BopCode) The API data type
-        [BopCode](https://www.imf.org/external/np/sta/bopcode/) is a JSON String
-        of 3 characters, consisting of digits only. Negative numbers are not
-        allowed. A leading zero is not allowed.
-      example: '123'
-    TransactionType:
-      title: TransactionType
-      type: object
-      description: Data model for the complex type TransactionType.
-      properties:
-        scenario:
-          $ref: '#/components/schemas/TransactionScenario'
-        subScenario:
-          $ref: '#/components/schemas/TransactionSubScenario'
-        initiator:
-          $ref: '#/components/schemas/TransactionInitiator'
-        initiatorType:
-          $ref: '#/components/schemas/TransactionInitiatorType'
-        refundInfo:
-          $ref: '#/components/schemas/Refund'
-        balanceOfPayments:
-          $ref: '#/components/schemas/BalanceOfPayments'
-      required:
-        - scenario
-        - initiator
-        - initiatorType
-    Note:
-      title: Note
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Memo assigned to transaction.
-      example: Note sent to Payee.
-    Transaction:
-      title: Transaction
-      type: object
-      description: >-
-        Data model for the complex type Transaction. The Transaction type is
-        used to carry end-to-end data between the Payer FSP and the Payee FSP in
-        the ILP Packet. Both the transactionId and the quoteId in the data model
-        are decided by the Payer FSP in the POST /quotes request.
-      properties:
-        transactionId:
-          $ref: '#/components/schemas/CorrelationId'
-        quoteId:
-          $ref: '#/components/schemas/CorrelationId'
-        payee:
-          $ref: '#/components/schemas/Party'
-        payer:
-          $ref: '#/components/schemas/Party'
-        amount:
-          $ref: '#/components/schemas/Money'
-        transactionType:
-          $ref: '#/components/schemas/TransactionType'
-        note:
-          $ref: '#/components/schemas/Note'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - transactionId
-        - quoteId
-        - payee
-        - payer
-        - amount
-        - transactionType
-    UndefinedEnum:
-      title: UndefinedEnum
-      type: string
-      pattern: ^[A-Z_]{1,32}$
-      description: >-
-        The API data type UndefinedEnum is a JSON String consisting of 1 to 32
-        uppercase characters including an underscore character (_).
-    ErrorCode:
-      title: ErrorCode
-      type: string
-      pattern: ^[1-9]\d{3}$
-      description: >-
-        The API data type ErrorCode is a JSON String of four characters,
-        consisting of digits only. Negative numbers are not allowed. A leading
-        zero is not allowed. Each error code in the API is a four-digit number,
-        for example, 1234, where the first number (1 in the example) represents
-        the high-level error category, the second number (2 in the example)
-        represents the low-level error category, and the last two numbers (34 in
-        the example) represent the specific error.
-      example: '5100'
-    ErrorDescription:
-      title: ErrorDescription
-      type: string
-      minLength: 1
-      maxLength: 128
-      description: Error description string.
-    ErrorInformation:
-      title: ErrorInformation
-      type: object
-      description: Data model for the complex type ErrorInformation.
-      properties:
-        errorCode:
-          $ref: '#/components/schemas/ErrorCode'
-        errorDescription:
-          $ref: '#/components/schemas/ErrorDescription'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - errorCode
-        - errorDescription
-    ErrorInformationResponse:
-      title: ErrorInformationResponse
-      type: object
-      description: >-
-        Data model for the complex type object that contains an optional element
-        ErrorInformation used along with 4xx and 5xx responses.
-      properties:
-        errorInformation:
-          $ref: '#/components/schemas/ErrorInformation'
-    ParticipantsTypeIDPutResponse:
-      title: ParticipantsTypeIDPutResponse
-      type: object
-      description: >-
-        The object sent in the PUT /participants/{Type}/{ID}/{SubId} and
-        /participants/{Type}/{ID} callbacks.
-      properties:
-        fspId:
-          $ref: '#/components/schemas/FspId'
-    ParticipantsTypeIDSubIDPostRequest:
-      title: ParticipantsTypeIDSubIDPostRequest
-      type: object
-      description: >-
-        The object sent in the POST /participants/{Type}/{ID}/{SubId} and
-        /participants/{Type}/{ID} requests. An additional optional ExtensionList
-        element has been added as part of v1.1 changes.
-      properties:
-        fspId:
-          $ref: '#/components/schemas/FspId'
-        currency:
-          $ref: '#/components/schemas/Currency'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - fspId
-    ErrorInformationObject:
-      title: ErrorInformationObject
-      type: object
-      description: Data model for the complex type object that contains ErrorInformation.
-      properties:
-        errorInformation:
-          $ref: '#/components/schemas/ErrorInformation'
-      required:
-        - errorInformation
-    ParticipantsPostRequest:
-      title: ParticipantsPostRequest
-      type: object
-      description: The object sent in the POST /participants request.
-      properties:
-        requestId:
-          $ref: '#/components/schemas/CorrelationId'
-        partyList:
-          type: array
-          items:
-            $ref: '#/components/schemas/PartyIdInfo'
-          minItems: 1
-          maxItems: 10000
-          description: >-
-            List of PartyIdInfo elements that the client would like to update or
-            create FSP information about.
-        currency:
-          $ref: '#/components/schemas/Currency'
-      required:
-        - requestId
-        - partyList
-    PartyResult:
-      title: PartyResult
-      type: object
-      description: Data model for the complex type PartyResult.
-      properties:
-        partyId:
-          $ref: '#/components/schemas/PartyIdInfo'
-        errorInformation:
-          $ref: '#/components/schemas/ErrorInformation'
-      required:
-        - partyId
-    ParticipantsIDPutResponse:
-      title: ParticipantsIDPutResponse
-      type: object
-      description: The object sent in the PUT /participants/{ID} callback.
-      properties:
-        partyList:
-          type: array
-          items:
-            $ref: '#/components/schemas/PartyResult'
-          minItems: 1
-          maxItems: 10000
-          description: >-
-            List of PartyResult elements that were either created or failed to
-            be created.
-        currency:
-          $ref: '#/components/schemas/Currency'
-      required:
-        - partyList
-    PartiesTypeIDPutResponse:
-      title: PartiesTypeIDPutResponse
-      type: object
-      description: The object sent in the PUT /parties/{Type}/{ID} callback.
-      properties:
-        party:
-          $ref: '#/components/schemas/Party'
-      required:
-        - party
-    Latitude:
-      title: Latitude
-      type: string
-      pattern: >-
-        ^(\+|-)?(?:90(?:(?:\.0{1,6})?)|(?:[0-9]|[1-8][0-9])(?:(?:\.[0-9]{1,6})?))$
-      description: >-
-        The API data type Latitude is a JSON String in a lexical format that is
-        restricted by a regular expression for interoperability reasons.
-      example: '+45.4215'
-    Longitude:
-      title: Longitude
-      type: string
-      pattern: >-
-        ^(\+|-)?(?:180(?:(?:\.0{1,6})?)|(?:[0-9]|[1-9][0-9]|1[0-7][0-9])(?:(?:\.[0-9]{1,6})?))$
-      description: >-
-        The API data type Longitude is a JSON String in a lexical format that is
-        restricted by a regular expression for interoperability reasons.
-      example: '+75.6972'
-    GeoCode:
-      title: GeoCode
-      type: object
-      description: >-
-        Data model for the complex type GeoCode. Indicates the geographic
-        location from where the transaction was initiated.
-      properties:
-        latitude:
-          $ref: '#/components/schemas/Latitude'
-        longitude:
-          $ref: '#/components/schemas/Longitude'
-      required:
-        - latitude
-        - longitude
-    AuthenticationType:
-      title: AuthenticationType
-      type: string
-      enum:
-        - OTP
-        - QRCODE
-        - U2F
-      description: |-
-        Below are the allowed values for the enumeration AuthenticationType.
-        - OTP - One-time password generated by the Payer FSP.
-        - QRCODE - QR code used as One Time Password.
-        - U2F - U2F is a new addition isolated to Thirdparty stream.
-      example: OTP
-    DateTime:
-      title: DateTime
-      type: string
-      pattern: >-
-        ^(?:[1-9]\d{3}-(?:(?:0[1-9]|1[0-2])-(?:0[1-9]|1\d|2[0-8])|(?:0[13-9]|1[0-2])-(?:29|30)|(?:0[13578]|1[02])-31)|(?:[1-9]\d(?:0[48]|[2468][048]|[13579][26])|(?:[2468][048]|[13579][26])00)-02-29)T(?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d(?:(\.\d{3}))(?:Z|[+-][01]\d:[0-5]\d)$
-      description: >-
-        The API data type DateTime is a JSON String in a lexical format that is
-        restricted by a regular expression for interoperability reasons. The
-        format is according to [ISO
-        8601](https://www.iso.org/iso-8601-date-and-time-format.html), expressed
-        in a combined date, time and time zone format. A more readable version
-        of the format is yyyy-MM-ddTHH:mm:ss.SSS[-HH:MM]. Examples are
-        "2016-05-24T08:38:08.699-04:00", "2016-05-24T08:38:08.699Z" (where Z
-        indicates Zulu time zone, same as UTC).
-      example: '2016-05-24T08:38:08.699-04:00'
-    TransactionRequestsPostRequest:
-      title: TransactionRequestsPostRequest
-      type: object
-      description: The object sent in the POST /transactionRequests request.
-      properties:
-        transactionRequestId:
-          $ref: '#/components/schemas/CorrelationId'
-        payee:
-          $ref: '#/components/schemas/Party'
-        payer:
-          $ref: '#/components/schemas/PartyIdInfo'
-        amount:
-          $ref: '#/components/schemas/Money'
-        transactionType:
-          $ref: '#/components/schemas/TransactionType'
-        note:
-          $ref: '#/components/schemas/Note'
-        geoCode:
-          $ref: '#/components/schemas/GeoCode'
-        authenticationType:
-          $ref: '#/components/schemas/AuthenticationType'
-        expiration:
-          $ref: '#/components/schemas/DateTime'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - transactionRequestId
-        - payee
-        - payer
-        - amount
-        - transactionType
     TransactionRequestState:
       title: TransactionRequestState
       type: string
@@ -3076,235 +3383,136 @@ components:
       description: The object sent in the PUT /transactionRequests/{ID} callback.
       properties:
         transactionId:
-          $ref: '#/components/schemas/CorrelationId'
+          $ref: "#/components/schemas/CorrelationId"
         transactionRequestState:
-          $ref: '#/components/schemas/TransactionRequestState'
+          $ref: "#/components/schemas/TransactionRequestState"
         extensionList:
-          $ref: '#/components/schemas/ExtensionList'
+          $ref: "#/components/schemas/ExtensionList"
       required:
         - transactionRequestState
-    AmountType:
-      title: AmountType
-      type: string
-      enum:
-        - SEND
-        - RECEIVE
-      description: >-
-        Below are the allowed values for the enumeration AmountType.
-
-        - SEND - Amount the Payer would like to send, that is, the amount that
-        should be withdrawn from the Payer account including any fees.
-
-        - RECEIVE - Amount the Payer would like the Payee to receive, that is,
-        the amount that should be sent to the receiver exclusive of any fees.
-      example: RECEIVE
-    QuotesPostRequest:
-      title: QuotesPostRequest
+    TransactionRequestsPostRequest:
+      title: TransactionRequestsPostRequest
       type: object
-      description: The object sent in the POST /quotes request.
+      description: The object sent in the POST /transactionRequests request.
       properties:
-        quoteId:
-          $ref: '#/components/schemas/CorrelationId'
-        transactionId:
-          $ref: '#/components/schemas/CorrelationId'
         transactionRequestId:
-          $ref: '#/components/schemas/CorrelationId'
+          $ref: "#/components/schemas/CorrelationId"
         payee:
-          $ref: '#/components/schemas/Party'
+          $ref: "#/components/schemas/Party"
         payer:
-          $ref: '#/components/schemas/Party'
-        amountType:
-          $ref: '#/components/schemas/AmountType'
+          $ref: "#/components/schemas/PartyIdInfo"
         amount:
-          $ref: '#/components/schemas/Money'
-        fees:
-          $ref: '#/components/schemas/Money'
+          $ref: "#/components/schemas/Money"
         transactionType:
-          $ref: '#/components/schemas/TransactionType'
-        geoCode:
-          $ref: '#/components/schemas/GeoCode'
+          $ref: "#/components/schemas/TransactionType"
         note:
-          $ref: '#/components/schemas/Note'
+          $ref: "#/components/schemas/Note"
+        geoCode:
+          $ref: "#/components/schemas/GeoCode"
+        authenticationType:
+          $ref: "#/components/schemas/AuthenticationType"
         expiration:
-          $ref: '#/components/schemas/DateTime'
+          $ref: "#/components/schemas/DateTime"
         extensionList:
-          $ref: '#/components/schemas/ExtensionList'
+          $ref: "#/components/schemas/ExtensionList"
       required:
-        - quoteId
-        - transactionId
+        - transactionRequestId
         - payee
         - payer
-        - amountType
         - amount
         - transactionType
-    IlpPacket:
-      title: IlpPacket
-      type: string
-      pattern: ^[A-Za-z0-9-_]+[=]{0,2}$
-      minLength: 1
-      maxLength: 32768
-      description: Information for recipient (transport layer information).
-      example: >-
-        AYIBgQAAAAAAAASwNGxldmVsb25lLmRmc3AxLm1lci45T2RTOF81MDdqUUZERmZlakgyOVc4bXFmNEpLMHlGTFGCAUBQU0svMS4wCk5vbmNlOiB1SXlweUYzY3pYSXBFdzVVc05TYWh3CkVuY3J5cHRpb246IG5vbmUKUGF5bWVudC1JZDogMTMyMzZhM2ItOGZhOC00MTYzLTg0NDctNGMzZWQzZGE5OGE3CgpDb250ZW50LUxlbmd0aDogMTM1CkNvbnRlbnQtVHlwZTogYXBwbGljYXRpb24vanNvbgpTZW5kZXItSWRlbnRpZmllcjogOTI4MDYzOTEKCiJ7XCJmZWVcIjowLFwidHJhbnNmZXJDb2RlXCI6XCJpbnZvaWNlXCIsXCJkZWJpdE5hbWVcIjpcImFsaWNlIGNvb3BlclwiLFwiY3JlZGl0TmFtZVwiOlwibWVyIGNoYW50XCIsXCJkZWJpdElkZW50aWZpZXJcIjpcIjkyODA2MzkxXCJ9IgA
-    IlpCondition:
-      title: IlpCondition
-      type: string
-      pattern: ^[A-Za-z0-9-_]{43}$
-      maxLength: 48
-      description: Condition that must be attached to the transfer by the Payer.
-    QuotesIDPutResponse:
-      title: QuotesIDPutResponse
-      type: object
-      description: The object sent in the PUT /quotes/{ID} callback.
-      properties:
-        transferAmount:
-          $ref: '#/components/schemas/Money'
-        payeeReceiveAmount:
-          $ref: '#/components/schemas/Money'
-        payeeFspFee:
-          $ref: '#/components/schemas/Money'
-        payeeFspCommission:
-          $ref: '#/components/schemas/Money'
-        expiration:
-          $ref: '#/components/schemas/DateTime'
-        geoCode:
-          $ref: '#/components/schemas/GeoCode'
-        ilpPacket:
-          $ref: '#/components/schemas/IlpPacket'
-        condition:
-          $ref: '#/components/schemas/IlpCondition'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - transferAmount
-        - expiration
-        - ilpPacket
-        - condition
-    OtpValue:
-      title: OtpValue
-      type: string
-      pattern: ^\d{3,10}$
-      description: >-
-        The API data type OtpValue is a JSON String of 3 to 10 characters,
-        consisting of digits only. Negative numbers are not allowed. One or more
-        leading zeros are allowed.
-    QRCODE:
-      title: QRCODE
-      type: string
-      minLength: 1
-      maxLength: 64
-      description: QR code used as a One Time Password.
-    U2FPIN:
-      title: U2FPIN
-      type: string
-      pattern: ^\S{1,64}$
-      minLength: 1
-      maxLength: 64
-      description: >
-        U2F challenge-response, where payer FSP verifies if the response
-        provided by end-user device matches the previously registered key.
-    U2FPinValue:
-      title: U2FPinValue
-      type: object
-      description: >
-        U2F challenge-response, where payer FSP verifies if the response
-        provided by end-user device matches the previously registered key.
-      properties:
-        pinValue:
-          allOf:
-            - $ref: '#/components/schemas/U2FPIN'
-          description: U2F challenge-response.
-        counter:
-          allOf:
-            - $ref: '#/components/schemas/Integer'
-          description: >-
-            Sequential counter used for cloning detection. Present only for U2F
-            authentication.
-      required:
-        - pinValue
-        - counter
-    AuthenticationValue:
-      title: AuthenticationValue
-      anyOf:
-        - $ref: '#/components/schemas/OtpValue'
-        - $ref: '#/components/schemas/QRCODE'
-        - $ref: '#/components/schemas/U2FPinValue'
-      pattern: ^\d{3,10}$|^\S{1,64}$
-      description: >-
-        Contains the authentication value. The format depends on the
-        authentication type used in the AuthenticationInfo complex type.
-    AuthenticationInfo:
-      title: AuthenticationInfo
-      type: object
-      description: Data model for the complex type AuthenticationInfo.
-      properties:
-        authentication:
-          $ref: '#/components/schemas/AuthenticationType'
-        authenticationValue:
-          $ref: '#/components/schemas/AuthenticationValue'
-      required:
-        - authentication
-        - authenticationValue
-    AuthorizationResponse:
-      title: AuthorizationResponse
+    TransactionScenario:
+      title: TransactionScenario
       type: string
       enum:
-        - ENTERED
+        - DEPOSIT
+        - WITHDRAWAL
+        - TRANSFER
+        - PAYMENT
+        - REFUND
+      description: >-
+        Below are the allowed values for the enumeration.
+
+        - DEPOSIT - Used for performing a Cash-In (deposit) transaction. In a
+        normal scenario, electronic funds are transferred from a Business
+        account to a Consumer account, and physical cash is given from the
+        Consumer to the Business User.
+
+        - WITHDRAWAL - Used for performing a Cash-Out (withdrawal) transaction.
+        In a normal scenario, electronic funds are transferred from a Consumer’s
+        account to a Business account, and physical cash is given from the
+        Business User to the Consumer.
+
+        - TRANSFER - Used for performing a P2P (Peer to Peer, or Consumer to
+        Consumer) transaction.
+
+        - PAYMENT - Usually used for performing a transaction from a Consumer to
+        a Merchant or Organization, but could also be for a B2B (Business to
+        Business) payment. The transaction could be online for a purchase in an
+        Internet store, in a physical store where both the Consumer and Business
+        User are present, a bill payment, a donation, and so on.
+
+        - REFUND - Used for performing a refund of transaction.
+      example: DEPOSIT
+    TransactionState:
+      title: TransactionState
+      type: string
+      enum:
+        - RECEIVED
+        - PENDING
+        - COMPLETED
         - REJECTED
-        - RESEND
       description: |-
         Below are the allowed values for the enumeration.
-        - ENTERED - Consumer entered the authentication value.
-        - REJECTED - Consumer rejected the transaction.
-        - RESEND - Consumer requested to resend the authentication value.
-      example: ENTERED
-    AuthorizationsIDPutResponse:
-      title: AuthorizationsIDPutResponse
-      type: object
-      description: The object sent in the PUT /authorizations/{ID} callback.
-      properties:
-        authenticationInfo:
-          $ref: '#/components/schemas/AuthenticationInfo'
-        responseType:
-          $ref: '#/components/schemas/AuthorizationResponse'
-      required:
-        - responseType
-    TransfersPostRequest:
-      title: TransfersPostRequest
-      type: object
-      description: The object sent in the POST /transfers request.
-      properties:
-        transferId:
-          $ref: '#/components/schemas/CorrelationId'
-        payeeFsp:
-          $ref: '#/components/schemas/FspId'
-        payerFsp:
-          $ref: '#/components/schemas/FspId'
-        amount:
-          $ref: '#/components/schemas/Money'
-        ilpPacket:
-          $ref: '#/components/schemas/IlpPacket'
-        condition:
-          $ref: '#/components/schemas/IlpCondition'
-        expiration:
-          $ref: '#/components/schemas/DateTime'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - transferId
-        - payeeFsp
-        - payerFsp
-        - amount
-        - ilpPacket
-        - condition
-        - expiration
-    IlpFulfilment:
-      title: IlpFulfilment
+        - RECEIVED - Payee FSP has received the transaction from the Payer FSP.
+        - PENDING - Payee FSP has validated the transaction.
+        - COMPLETED - Payee FSP has successfully performed the transaction.
+        - REJECTED - Payee FSP has failed to perform the transaction.
+      example: RECEIVED
+    TransactionSubScenario:
+      title: TransactionSubScenario
       type: string
-      pattern: ^[A-Za-z0-9-_]{43}$
-      maxLength: 48
-      description: Fulfilment that must be attached to the transfer by the Payee.
-      example: WLctttbu2HvTsa1XWvUoGRcQozHsqeu9Ahl2JW9Bsu8
+      pattern: ^[A-Z_]{1,32}$
+      description: >-
+        Possible sub-scenario, defined locally within the scheme (UndefinedEnum
+        Type).
+      example: LOCALLY_DEFINED_SUBSCENARIO
+    TransactionType:
+      title: TransactionType
+      type: object
+      description: Data model for the complex type TransactionType.
+      properties:
+        scenario:
+          $ref: "#/components/schemas/TransactionScenario"
+        subScenario:
+          $ref: "#/components/schemas/TransactionSubScenario"
+        initiator:
+          $ref: "#/components/schemas/TransactionInitiator"
+        initiatorType:
+          $ref: "#/components/schemas/TransactionInitiatorType"
+        refundInfo:
+          $ref: "#/components/schemas/Refund"
+        balanceOfPayments:
+          $ref: "#/components/schemas/BalanceOfPayments"
+      required:
+        - scenario
+        - initiator
+        - initiatorType
+    TransactionsIDPutResponse:
+      title: TransactionsIDPutResponse
+      type: object
+      description: The object sent in the PUT /transactions/{ID} callback.
+      properties:
+        completedTimestamp:
+          $ref: "#/components/schemas/DateTime"
+        transactionState:
+          $ref: "#/components/schemas/TransactionState"
+        code:
+          $ref: "#/components/schemas/Code"
+        extensionList:
+          $ref: "#/components/schemas/ExtensionList"
+      required:
+        - transactionState
     TransferState:
       title: TransferState
       type: string
@@ -3325,299 +3533,123 @@ components:
         - ABORTED - Next ledger has aborted the transfer due to a rejection or
         failure to perform the transfer.
       example: RESERVED
-    TransfersIDPutResponse:
-      title: TransfersIDPutResponse
-      type: object
-      description: The object sent in the PUT /transfers/{ID} callback.
-      properties:
-        fulfilment:
-          $ref: '#/components/schemas/IlpFulfilment'
-        completedTimestamp:
-          $ref: '#/components/schemas/DateTime'
-        transferState:
-          $ref: '#/components/schemas/TransferState'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - transferState
     TransfersIDPatchResponse:
       title: TransfersIDPatchResponse
       type: object
       description: PATCH /transfers/{ID} object
       properties:
         completedTimestamp:
-          $ref: '#/components/schemas/DateTime'
+          $ref: "#/components/schemas/DateTime"
         transferState:
-          $ref: '#/components/schemas/TransferState'
+          $ref: "#/components/schemas/TransferState"
         extensionList:
-          $ref: '#/components/schemas/ExtensionList'
+          $ref: "#/components/schemas/ExtensionList"
       required:
         - completedTimestamp
         - transferState
-    TransactionState:
-      title: TransactionState
-      type: string
-      enum:
-        - RECEIVED
-        - PENDING
-        - COMPLETED
-        - REJECTED
-      description: |-
-        Below are the allowed values for the enumeration.
-        - RECEIVED - Payee FSP has received the transaction from the Payer FSP.
-        - PENDING - Payee FSP has validated the transaction.
-        - COMPLETED - Payee FSP has successfully performed the transaction.
-        - REJECTED - Payee FSP has failed to perform the transaction.
-      example: RECEIVED
-    Code:
-      title: Code
-      type: string
-      pattern: ^[0-9a-zA-Z]{4,32}$
-      description: Any code/token returned by the Payee FSP (TokenCode Type).
-      example: Test-Code
-    TransactionsIDPutResponse:
-      title: TransactionsIDPutResponse
+    TransfersIDPutResponse:
+      title: TransfersIDPutResponse
       type: object
-      description: The object sent in the PUT /transactions/{ID} callback.
+      description: The object sent in the PUT /transfers/{ID} callback.
       properties:
+        fulfilment:
+          $ref: "#/components/schemas/IlpFulfilment"
         completedTimestamp:
-          $ref: '#/components/schemas/DateTime'
-        transactionState:
-          $ref: '#/components/schemas/TransactionState'
-        code:
-          $ref: '#/components/schemas/Code'
+          $ref: "#/components/schemas/DateTime"
+        transferState:
+          $ref: "#/components/schemas/TransferState"
         extensionList:
-          $ref: '#/components/schemas/ExtensionList'
+          $ref: "#/components/schemas/ExtensionList"
       required:
-        - transactionState
-    IndividualQuote:
-      title: IndividualQuote
+        - transferState
+    TransfersPostRequest:
+      title: TransfersPostRequest
       type: object
-      description: Data model for the complex type IndividualQuote.
-      properties:
-        quoteId:
-          $ref: '#/components/schemas/CorrelationId'
-        transactionId:
-          $ref: '#/components/schemas/CorrelationId'
-        payee:
-          $ref: '#/components/schemas/Party'
-        amountType:
-          $ref: '#/components/schemas/AmountType'
-        amount:
-          $ref: '#/components/schemas/Money'
-        fees:
-          $ref: '#/components/schemas/Money'
-        transactionType:
-          $ref: '#/components/schemas/TransactionType'
-        note:
-          $ref: '#/components/schemas/Note'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - quoteId
-        - transactionId
-        - payee
-        - amountType
-        - amount
-        - transactionType
-    BulkQuotesPostRequest:
-      title: BulkQuotesPostRequest
-      type: object
-      description: The object sent in the POST /bulkQuotes request.
-      properties:
-        bulkQuoteId:
-          $ref: '#/components/schemas/CorrelationId'
-        payer:
-          $ref: '#/components/schemas/Party'
-        geoCode:
-          $ref: '#/components/schemas/GeoCode'
-        expiration:
-          $ref: '#/components/schemas/DateTime'
-        individualQuotes:
-          type: array
-          minItems: 1
-          maxItems: 1000
-          items:
-            $ref: '#/components/schemas/IndividualQuote'
-          description: List of quotes elements.
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - bulkQuoteId
-        - payer
-        - individualQuotes
-    IndividualQuoteResult:
-      title: IndividualQuoteResult
-      type: object
-      description: Data model for the complex type IndividualQuoteResult.
-      properties:
-        quoteId:
-          $ref: '#/components/schemas/CorrelationId'
-        payee:
-          $ref: '#/components/schemas/Party'
-        transferAmount:
-          $ref: '#/components/schemas/Money'
-        payeeReceiveAmount:
-          $ref: '#/components/schemas/Money'
-        payeeFspFee:
-          $ref: '#/components/schemas/Money'
-        payeeFspCommission:
-          $ref: '#/components/schemas/Money'
-        ilpPacket:
-          $ref: '#/components/schemas/IlpPacket'
-        condition:
-          $ref: '#/components/schemas/IlpCondition'
-        errorInformation:
-          $ref: '#/components/schemas/ErrorInformation'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - quoteId
-    BulkQuotesIDPutResponse:
-      title: BulkQuotesIDPutResponse
-      type: object
-      description: The object sent in the PUT /bulkQuotes/{ID} callback.
-      properties:
-        individualQuoteResults:
-          type: array
-          maxItems: 1000
-          items:
-            $ref: '#/components/schemas/IndividualQuoteResult'
-          description: >-
-            Fees for each individual transaction, if any of them are charged per
-            transaction.
-        expiration:
-          $ref: '#/components/schemas/DateTime'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - expiration
-    IndividualTransfer:
-      title: IndividualTransfer
-      type: object
-      description: Data model for the complex type IndividualTransfer.
+      description: The object sent in the POST /transfers request.
       properties:
         transferId:
-          $ref: '#/components/schemas/CorrelationId'
-        transferAmount:
-          $ref: '#/components/schemas/Money'
+          $ref: "#/components/schemas/CorrelationId"
+        payeeFsp:
+          $ref: "#/components/schemas/FspId"
+        payerFsp:
+          $ref: "#/components/schemas/FspId"
+        amount:
+          $ref: "#/components/schemas/Money"
         ilpPacket:
-          $ref: '#/components/schemas/IlpPacket'
+          $ref: "#/components/schemas/IlpPacket"
         condition:
-          $ref: '#/components/schemas/IlpCondition'
+          $ref: "#/components/schemas/IlpCondition"
+        expiration:
+          $ref: "#/components/schemas/DateTime"
         extensionList:
-          $ref: '#/components/schemas/ExtensionList'
+          $ref: "#/components/schemas/ExtensionList"
       required:
         - transferId
-        - transferAmount
+        - payeeFsp
+        - payerFsp
+        - amount
         - ilpPacket
         - condition
-    BulkTransfersPostRequest:
-      title: BulkTransfersPostRequest
-      type: object
-      description: The object sent in the POST /bulkTransfers request.
-      properties:
-        bulkTransferId:
-          $ref: '#/components/schemas/CorrelationId'
-        bulkQuoteId:
-          $ref: '#/components/schemas/CorrelationId'
-        payerFsp:
-          $ref: '#/components/schemas/FspId'
-        payeeFsp:
-          $ref: '#/components/schemas/FspId'
-        individualTransfers:
-          type: array
-          minItems: 1
-          maxItems: 1000
-          items:
-            $ref: '#/components/schemas/IndividualTransfer'
-          description: List of IndividualTransfer elements.
-        expiration:
-          $ref: '#/components/schemas/DateTime'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - bulkTransferId
-        - bulkQuoteId
-        - payerFsp
-        - payeeFsp
-        - individualTransfers
         - expiration
-    IndividualTransferResult:
-      title: IndividualTransferResult
-      type: object
-      description: Data model for the complex type IndividualTransferResult.
-      properties:
-        transferId:
-          $ref: '#/components/schemas/CorrelationId'
-        fulfilment:
-          $ref: '#/components/schemas/IlpFulfilment'
-        errorInformation:
-          $ref: '#/components/schemas/ErrorInformation'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
-      required:
-        - transferId
-    BulkTransferState:
-      title: BulkTransactionState
+    U2FPIN:
+      title: U2FPIN
       type: string
-      enum:
-        - RECEIVED
-        - PENDING
-        - ACCEPTED
-        - PROCESSING
-        - COMPLETED
-        - REJECTED
-      description: >-
-        Below are the allowed values for the enumeration.
-
-        - RECEIVED - Payee FSP has received the bulk transfer from the Payer
-        FSP.
-
-        - PENDING - Payee FSP has validated the bulk transfer.
-
-        - ACCEPTED - Payee FSP has accepted to process the bulk transfer.
-
-        - PROCESSING - Payee FSP has started to transfer fund to the Payees.
-
-        - COMPLETED - Payee FSP has completed transfer of funds to the Payees.
-
-        - REJECTED - Payee FSP has rejected to process the bulk transfer.
-      example: RECEIVED
-    BulkTransfersIDPutResponse:
-      title: BulkTransfersIDPutResponse
+      pattern: ^\S{1,64}$
+      minLength: 1
+      maxLength: 64
+      description: >
+        U2F challenge-response, where payer FSP verifies if the response
+        provided by end-user device matches the previously registered key.
+    U2FPinValue:
+      title: U2FPinValue
       type: object
-      description: The object sent in the PUT /bulkTransfers/{ID} callback.
+      description: >
+        U2F challenge-response, where payer FSP verifies if the response
+        provided by end-user device matches the previously registered key.
       properties:
-        completedTimestamp:
-          $ref: '#/components/schemas/DateTime'
-        individualTransferResults:
-          type: array
-          maxItems: 1000
-          items:
-            $ref: '#/components/schemas/IndividualTransferResult'
-          description: List of IndividualTransferResult elements.
-        bulkTransferState:
-          $ref: '#/components/schemas/BulkTransferState'
-        extensionList:
-          $ref: '#/components/schemas/ExtensionList'
+        pinValue:
+          allOf:
+            - $ref: "#/components/schemas/U2FPIN"
+          description: U2F challenge-response.
+        counter:
+          allOf:
+            - $ref: "#/components/schemas/Integer"
+          description: >-
+            Sequential counter used for cloning detection. Present only for U2F
+            authentication.
       required:
-        - bulkTransferState
+        - pinValue
+        - counter
+    UndefinedEnum:
+      title: UndefinedEnum
+      type: string
+      pattern: ^[A-Z_]{1,32}$
+      description: >-
+        The API data type UndefinedEnum is a JSON String consisting of 1 to 32
+        uppercase characters including an underscore character (_).
   parameters:
-    Type:
-      name: Type
-      in: path
+    Accept:
+      name: Accept
+      in: header
       required: true
       schema:
         type: string
-      description: The type of the party identifier. For example, `MSISDN`, `PERSONAL_ID`.
-    ID:
-      name: ID
-      in: path
-      required: true
+      description: >-
+        The `Accept` header field indicates the version of the API the client
+        would like the server to use.
+    Content-Length:
+      name: Content-Length
+      in: header
+      required: false
       schema:
-        type: string
-      description: The identifier value.
+        type: integer
+      description: >-
+        The `Content-Length` header field indicates the anticipated size of the
+        payload body. Only sent if there is a body.
+
+
+        **Note:** The API supports a maximum size of 5242880 bytes (5
+        Megabytes).
     Content-Type:
       name: Content-Type
       in: header
@@ -3634,34 +3666,6 @@ components:
         type: string
       required: true
       description: The `Date` header field indicates the date when the request was sent.
-    X-Forwarded-For:
-      name: X-Forwarded-For
-      in: header
-      schema:
-        type: string
-      required: false
-      description: >-
-        The `X-Forwarded-For` header field is an unofficially accepted standard
-        used for informational purposes of the originating client IP address, as
-        a request might pass multiple proxies, firewalls, and so on. Multiple
-        `X-Forwarded-For` values should be expected and supported by
-        implementers of the API.
-
-
-        **Note:** An alternative to `X-Forwarded-For` is defined in [RFC
-        7239](https://tools.ietf.org/html/rfc7239). However, to this point RFC
-        7239 is less-used and supported than `X-Forwarded-For`.
-    FSPIOP-Source:
-      name: FSPIOP-Source
-      in: header
-      schema:
-        type: string
-      required: true
-      description: >-
-        The `FSPIOP-Source` header field is a non-HTTP standard field used by
-        the API for identifying the sender of the HTTP request. The field should
-        be set by the original sender of the request. Required for routing and
-        signature verification (see header field `FSPIOP-Signature`).
     FSPIOP-Destination:
       name: FSPIOP-Destination
       in: header
@@ -3686,27 +3690,6 @@ components:
       description: >-
         The `FSPIOP-Encryption` header field is a non-HTTP standard field used
         by the API for applying end-to-end encryption of the request.
-    FSPIOP-Signature:
-      name: FSPIOP-Signature
-      in: header
-      schema:
-        type: string
-      required: false
-      description: >-
-        The `FSPIOP-Signature` header field is a non-HTTP standard field used by
-        the API for applying an end-to-end request signature.
-    FSPIOP-URI:
-      name: FSPIOP-URI
-      in: header
-      schema:
-        type: string
-      required: false
-      description: >-
-        The `FSPIOP-URI` header field is a non-HTTP standard field used by the
-        API for signature verification, should contain the service URI. Required
-        if signature verification is used, for more information, see [the API
-        Signature
-        document](https://github.com/mojaloop/docs/tree/main/Specification%20Document%20Set).
     FSPIOP-HTTP-Method:
       name: FSPIOP-HTTP-Method
       in: header
@@ -3719,28 +3702,45 @@ components:
         method. Required if signature verification is used, for more
         information, see [the API Signature
         document](https://github.com/mojaloop/docs/tree/main/Specification%20Document%20Set).
-    Accept:
-      name: Accept
+    FSPIOP-Signature:
+      name: FSPIOP-Signature
       in: header
+      schema:
+        type: string
+      required: false
+      description: >-
+        The `FSPIOP-Signature` header field is a non-HTTP standard field used by
+        the API for applying an end-to-end request signature.
+    FSPIOP-Source:
+      name: FSPIOP-Source
+      in: header
+      schema:
+        type: string
+      required: true
+      description: >-
+        The `FSPIOP-Source` header field is a non-HTTP standard field used by
+        the API for identifying the sender of the HTTP request. The field should
+        be set by the original sender of the request. Required for routing and
+        signature verification (see header field `FSPIOP-Signature`).
+    FSPIOP-URI:
+      name: FSPIOP-URI
+      in: header
+      schema:
+        type: string
+      required: false
+      description: >-
+        The `FSPIOP-URI` header field is a non-HTTP standard field used by the
+        API for signature verification, should contain the service URI. Required
+        if signature verification is used, for more information, see [the API
+        Signature
+        document](https://github.com/mojaloop/docs/tree/main/Specification%20Document%20Set).
+    ID:
+      name: ID
+      in: path
       required: true
       schema:
         type: string
-      description: >-
-        The `Accept` header field indicates the version of the API the client
-        would like the server to use.
-    Content-Length:
-      name: Content-Length
-      in: header
-      required: false
-      schema:
-        type: integer
-      description: >-
-        The `Content-Length` header field indicates the anticipated size of the
-        payload body. Only sent if there is a body.
-
-
-        **Note:** The API supports a maximum size of 5242880 bytes (5
-        Megabytes).
+      description: The identifier value.
     SubId:
       name: SubId
       in: path
@@ -3750,99 +3750,123 @@ components:
       description: >-
         A sub-identifier of the party identifier, or a sub-type of the party
         identifier's type. For example, `PASSPORT`, `DRIVING_LICENSE`.
+    Type:
+      name: Type
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The type of the party identifier. For example, `MSISDN`, `PERSONAL_ID`.
+    X-Forwarded-For:
+      name: X-Forwarded-For
+      in: header
+      schema:
+        type: string
+      required: false
+      description: >-
+        The `X-Forwarded-For` header field is an unofficially accepted standard
+        used for informational purposes of the originating client IP address, as
+        a request might pass multiple proxies, firewalls, and so on. Multiple
+        `X-Forwarded-For` values should be expected and supported by
+        implementers of the API.
+
+
+        **Note:** An alternative to `X-Forwarded-For` is defined in [RFC
+        7239](https://tools.ietf.org/html/rfc7239). However, to this point RFC
+        7239 is less-used and supported than `X-Forwarded-For`.
   responses:
-    '200':
+    "200":
       description: OK
-    '202':
+    "202":
       description: Accepted
-    '400':
+    "400":
       description: Bad Request
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorInformationResponse'
+            $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: '#/components/headers/Content-Length'
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: '#/components/headers/Content-Type'
-    '401':
+          $ref: "#/components/headers/Content-Type"
+    "401":
       description: Unauthorized
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorInformationResponse'
+            $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: '#/components/headers/Content-Length'
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: '#/components/headers/Content-Type'
-    '403':
+          $ref: "#/components/headers/Content-Type"
+    "403":
       description: Forbidden
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorInformationResponse'
+            $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: '#/components/headers/Content-Length'
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: '#/components/headers/Content-Type'
-    '404':
+          $ref: "#/components/headers/Content-Type"
+    "404":
       description: Not Found
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorInformationResponse'
+            $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: '#/components/headers/Content-Length'
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: '#/components/headers/Content-Type'
-    '405':
+          $ref: "#/components/headers/Content-Type"
+    "405":
       description: Method Not Allowed
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorInformationResponse'
+            $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: '#/components/headers/Content-Length'
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: '#/components/headers/Content-Type'
-    '406':
+          $ref: "#/components/headers/Content-Type"
+    "406":
       description: Not Acceptable
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorInformationResponse'
+            $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: '#/components/headers/Content-Length'
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: '#/components/headers/Content-Type'
-    '501':
+          $ref: "#/components/headers/Content-Type"
+    "501":
       description: Not Implemented
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorInformationResponse'
+            $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: '#/components/headers/Content-Length'
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: '#/components/headers/Content-Type'
-    '503':
+          $ref: "#/components/headers/Content-Type"
+    "503":
       description: Service Unavailable
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorInformationResponse'
+            $ref: "#/components/schemas/ErrorInformationResponse"
       headers:
         Content-Length:
-          $ref: '#/components/headers/Content-Length'
+          $ref: "#/components/headers/Content-Length"
         Content-Type:
-          $ref: '#/components/headers/Content-Type'
+          $ref: "#/components/headers/Content-Type"
   headers:
     Content-Length:
       required: false


### PR DESCRIPTION
As some swagger validators showing errors with the existing fspiop 1.1 openapi specification file, I copied the one from api-snippets library which is more stable.